### PR TITLE
SalesforceConnector

### DIFF
--- a/cfn.yaml
+++ b/cfn.yaml
@@ -20,6 +20,11 @@ Mappings:
   StageMap:
     PROD:
       Schedule: 'rate(30 minutes)'
+      SalesforceStage: DEV
+      SalesforceUsername: pfCommsAPIUser
+      SalesforceAppName: AwsConnectorSandbox
+      SalesforceAppSecretsVersion: b7b63e09-f39f-4e4f-80ef-9dd203c2d59b
+      SalesforceUserSecretsVersion: 7f0a5fba-166f-44aa-8b1f-b8b1977cce82
       IdapiInstanceUrl: idapi.theguardian.com
       IdapiStage: PROD
       IdapiSecretsVersion: 190ff297-e512-4c87-a88b-015f863f8285
@@ -28,6 +33,11 @@ Mappings:
       BrazeSecretsVersion: 454bfb7f-ea8f-4870-be4b-a7068d2e16f4
     CODE:
       Schedule: 'rate(365 days)'
+      SalesforceStage: DEV
+      SalesforceUsername: pfCommsAPIUser
+      SalesforceAppName: AwsConnectorSandbox
+      SalesforceAppSecretsVersion: b7b63e09-f39f-4e4f-80ef-9dd203c2d59b
+      SalesforceUserSecretsVersion: 7f0a5fba-166f-44aa-8b1f-b8b1977cce82
       IdapiInstanceUrl: idapi.code.dev-theguardian.com
       IdapiStage: CODE
       IdapiSecretsVersion: 4349b3d1-5dc4-4a44-bded-263fff6dbdaa
@@ -36,6 +46,11 @@ Mappings:
       BrazeSecretsVersion: 454bfb7f-ea8f-4870-be4b-a7068d2e16f4
     DEV:
       Schedule: 'rate(365 days)'
+      SalesforceStage: DEV
+      SalesforceUsername: pfCommsAPIUser
+      SalesforceAppName: AwsConnectorSandbox
+      SalesforceAppSecretsVersion: b7b63e09-f39f-4e4f-80ef-9dd203c2d59b
+      SalesforceUserSecretsVersion: 7f0a5fba-166f-44aa-8b1f-b8b1977cce82
       IdapiInstanceUrl: idapi.code.dev-theguardian.com
       IdapiStage: CODE
       IdapiSecretsVersion: 4349b3d1-5dc4-4a44-bded-263fff6dbdaa
@@ -64,6 +79,43 @@ Resources:
       MemorySize: 256
       Environment:
         Variables:
+          salesforceApiVersion: v46.0
+          salesforceInstanceUrl:
+            !Sub
+            - '{{resolve:secretsmanager:${SalesforceStage}/Salesforce/ConnectedApp/${SalesforceAppName}:SecretString:authUrl::${SalesforceAppSecretsVersion}}}'
+            - SalesforceStage: !FindInMap [ StageMap, !Ref Stage, SalesforceStage ]
+              SalesforceAppName: !FindInMap [ StageMap, !Ref Stage, SalesforceAppName ]
+              SalesforceAppSecretsVersion: !FindInMap [ StageMap, !Ref Stage, SalesforceAppSecretsVersion ]
+          salesforceClientId:
+            !Sub
+            - '{{resolve:secretsmanager:${SalesforceStage}/Salesforce/ConnectedApp/${SalesforceAppName}:SecretString:clientId::${SalesforceAppSecretsVersion}}}'
+            - SalesforceStage: !FindInMap [ StageMap, !Ref Stage, SalesforceStage ]
+              SalesforceAppName: !FindInMap [ StageMap, !Ref Stage, SalesforceAppName ]
+              SalesforceAppSecretsVersion: !FindInMap [ StageMap, !Ref Stage, SalesforceAppSecretsVersion ]
+          salesforceClientSecret:
+            !Sub
+            - '{{resolve:secretsmanager:${SalesforceStage}/Salesforce/ConnectedApp/${SalesforceAppName}:SecretString:clientSecret::${SalesforceAppSecretsVersion}}}'
+            - SalesforceStage: !FindInMap [ StageMap, !Ref Stage, SalesforceStage ]
+              SalesforceAppName: !FindInMap [ StageMap, !Ref Stage, SalesforceAppName ]
+              SalesforceAppSecretsVersion: !FindInMap [ StageMap, !Ref Stage, SalesforceAppSecretsVersion ]
+          salesforceUsername:
+            !Sub
+            - '{{resolve:secretsmanager:${SalesforceStage}/Salesforce/User/${SalesforceUsername}:SecretString:sfUsername::${SalesforceUserSecretsVersion}}}'
+            - SalesforceStage: !FindInMap [ StageMap, !Ref Stage, SalesforceStage ]
+              SalesforceUserSecretsVersion: !FindInMap [ StageMap, !Ref Stage, SalesforceUserSecretsVersion ]
+              SalesforceUsername: !FindInMap [ StageMap, !Ref Stage, SalesforceUsername ]
+          salesforcePassword:
+            !Sub
+            - '{{resolve:secretsmanager:${SalesforceStage}/Salesforce/User/${SalesforceUsername}:SecretString:sfPassword::${SalesforceUserSecretsVersion}}}'
+            - SalesforceStage: !FindInMap [ StageMap, !Ref Stage, SalesforceStage ]
+              SalesforceUserSecretsVersion: !FindInMap [ StageMap, !Ref Stage, SalesforceUserSecretsVersion ]
+              SalesforceUsername: !FindInMap [ StageMap, !Ref Stage, SalesforceUsername ]
+          salesforceToken:
+            !Sub
+            - '{{resolve:secretsmanager:${SalesforceStage}/Salesforce/User/${SalesforceUsername}:SecretString:sfToken::${SalesforceUserSecretsVersion}}}'
+            - SalesforceStage: !FindInMap [ StageMap, !Ref Stage, SalesforceStage ]
+              SalesforceUserSecretsVersion: !FindInMap [ StageMap, !Ref Stage, SalesforceUserSecretsVersion ]
+              SalesforceUsername: !FindInMap [ StageMap, !Ref Stage, SalesforceUsername ]
           idapiInstanceUrl: !FindInMap [ StageMap, !Ref Stage, IdapiInstanceUrl ]
           idapiBearerToken: !Sub
             - '{{resolve:secretsmanager:IDAPI/${IDAPIStage}/${AppName}:SecretString:bearerToken::${IDAPISecretsVersion}}}'

--- a/src/main/scala/payment_failure_comms/SalesforceConnector.scala
+++ b/src/main/scala/payment_failure_comms/SalesforceConnector.scala
@@ -104,7 +104,7 @@ object SalesforceConnector {
     ).toEither
   }
 
-  def queryRequest(url: String, bearerToken: String, query: String) = {
+  def queryRequest(url: String, bearerToken: String, query: String): Either[Throwable, Response] = {
     val urlWithParam = HttpUrl
       .parse(url)
       .newBuilder()
@@ -122,7 +122,7 @@ object SalesforceConnector {
     ).toEither
   }
 
-  def compositeRequest(url: String, bearerToken: String, body: RequestBody) = {
+  def compositeRequest(url: String, bearerToken: String, body: RequestBody): Either[Throwable, Response] = {
     val request: Request = new Request.Builder()
       .header("Authorization", s"Bearer ${bearerToken}")
       .url(url)

--- a/src/main/scala/payment_failure_comms/SalesforceConnector.scala
+++ b/src/main/scala/payment_failure_comms/SalesforceConnector.scala
@@ -1,0 +1,160 @@
+package payment_failure_comms
+
+import io.circe.Decoder
+import io.circe.generic.auto.*
+import io.circe.syntax.*
+import io.circe.parser.decode
+import okhttp3.{HttpUrl, MediaType, OkHttpClient, Request, RequestBody, Response}
+import payment_failure_comms.models.{
+  Failure,
+  PaymentFailureRecord,
+  SFCompositeResponse,
+  SFPaymentFailureRecordWrapper,
+  SFResponse,
+  SalesforceAuth,
+  SalesforceConfig,
+  SalesforceRequestFailure,
+  SalesforceResponseFailure
+}
+
+import scala.util.Try
+
+case class PaymentFailureRecordUpdate()
+
+class SalesforceConnector(authDetails: SalesforceAuth, apiVersion: String) {
+  def getRecordsToProcess(): Either[Failure, Seq[PaymentFailureRecord]] =
+    SalesforceConnector.getRecordsToProcess(authDetails, apiVersion)
+
+  def updateRecords(records: Seq[PaymentFailureRecordUpdate]): Either[Failure, SFCompositeResponse] =
+    SalesforceConnector.updateRecords(authDetails, apiVersion, records)
+}
+
+object SalesforceConnector {
+
+  private val urlEncoded = MediaType.parse("application/x-www-form-urlencoded")
+  private val JSON: MediaType = MediaType.get("application/json; charset=utf-8")
+  private val http = new OkHttpClient()
+
+  def apply(sfConfig: SalesforceConfig): Either[Failure, SalesforceConnector] = {
+    auth(sfConfig)
+      .map(new SalesforceConnector(_, sfConfig.apiVersion))
+  }
+
+  def auth(sfConfig: SalesforceConfig): Either[Failure, SalesforceAuth] = {
+    handleRequestResult[SalesforceAuth](
+      authRequest(sfConfig)
+    )
+  }
+
+  def getRecordsToProcess(
+      authDetails: SalesforceAuth,
+      apiVersion: String
+  ): Either[Failure, Seq[PaymentFailureRecord]] = {
+    val query = "TBD"
+
+    handleRequestResult[SFPaymentFailureRecordWrapper](
+      queryRequest(
+        url = s"${authDetails.instance_url}/services/data/$apiVersion/query/",
+        bearerToken = authDetails.access_token,
+        query = query
+      )
+    )
+      .map(_.records)
+  }
+
+  def updateRecords(
+      authDetails: SalesforceAuth,
+      apiVersion: String,
+      records: Seq[PaymentFailureRecordUpdate]
+  ): Either[Failure, SFCompositeResponse] = {
+    val body = RequestBody.create(records.asJson.toString, JSON)
+
+    handleRequestResult[Seq[SFResponse]](
+      compositeRequest(
+        url = s"${authDetails.instance_url}/services/data/$apiVersion/composite/sobjects",
+        bearerToken = authDetails.access_token,
+        body
+      )
+    )
+      .map(responses => SFCompositeResponse(responses))
+
+  }
+
+  def authRequest(sfConfig: SalesforceConfig): Either[Throwable, Response] = {
+    val authDetails = Seq(
+      "grant_type" -> "password",
+      "client_id" -> sfConfig.clientId,
+      "client_secret" -> sfConfig.clientSecret,
+      "username" -> sfConfig.username,
+      "password" -> s"${sfConfig.password}${sfConfig.token}"
+    )
+      .map(_.productIterator.mkString("="))
+      .mkString("&")
+
+    val body = RequestBody.create(authDetails, urlEncoded)
+
+    val request = new Request.Builder()
+      .url(s"${sfConfig.instanceUrl}/services/oauth2/token")
+      .post(body)
+      .build()
+
+    Try(
+      http.newCall(request).execute()
+    ).toEither
+  }
+
+  def queryRequest(url: String, bearerToken: String, query: String) = {
+    val urlWithParam = HttpUrl
+      .parse(url)
+      .newBuilder()
+      .addQueryParameter("q", query)
+      .build();
+
+    val request: Request = new Request.Builder()
+      .header("Authorization", s"Bearer ${bearerToken}")
+      .url(urlWithParam)
+      .get()
+      .build()
+
+    Try(
+      http.newCall(request).execute()
+    ).toEither
+  }
+
+  def compositeRequest(url: String, bearerToken: String, body: RequestBody) = {
+    val request: Request = new Request.Builder()
+      .header("Authorization", s"Bearer ${bearerToken}")
+      .url(url)
+      .patch(body)
+      .build()
+
+    Try(
+      http.newCall(request).execute()
+    ).toEither
+  }
+
+  def handleRequestResult[T: Decoder](result: Either[Throwable, Response]): Either[Failure, T] = {
+    result
+      .left.map(i => SalesforceRequestFailure(s"Attempt to contact Salesforce failed with error: ${i.toString}"))
+      .flatMap { response =>
+        val body = response.body().string()
+
+        if (response.isSuccessful) {
+
+          decode[T](body)
+            .left.map(decodeError =>
+              SalesforceResponseFailure(
+                s"Failed to decode successful response:$decodeError. Body to decode ${body}"
+              )
+            )
+        } else {
+          Left(
+            SalesforceResponseFailure(
+              s"The request to Salesforce was unsuccessful: ${response.code} - ${body}"
+            )
+          )
+        }
+      }
+  }
+
+}

--- a/src/main/scala/payment_failure_comms/SalesforceConnector.scala
+++ b/src/main/scala/payment_failure_comms/SalesforceConnector.scala
@@ -50,6 +50,7 @@ object SalesforceConnector {
       authDetails: SalesforceAuth,
       apiVersion: String
   ): Either[Failure, Seq[PaymentFailureRecord]] = {
+    // TODO: Replace with actual query
     val query = "TBD"
 
     handleRequestResult[SFPaymentFailureRecordWrapper](

--- a/src/main/scala/payment_failure_comms/models/Config.scala
+++ b/src/main/scala/payment_failure_comms/models/Config.scala
@@ -1,6 +1,16 @@
 package payment_failure_comms.models
 
-case class Config(idapi: IdapiConfig, braze: BrazeConfig)
+case class Config(salesforce: SalesforceConfig, idapi: IdapiConfig, braze: BrazeConfig)
+
+case class SalesforceConfig(
+    instanceUrl: String,
+    apiVersion: String,
+    clientId: String,
+    clientSecret: String,
+    username: String,
+    password: String,
+    token: String
+)
 
 case class IdapiConfig(instanceUrl: String, bearerToken: String)
 
@@ -12,12 +22,28 @@ object Config {
       sys.env.get(prop).toRight(ConfigFailure(s"Could not obtain $prop"))
 
     for {
+      salesforceInstanceUrl <- getFromEnv("salesforceInstanceUrl")
+      salesforceApiVersion <- getFromEnv("salesforceApiVersion")
+      salesforceClientId <- getFromEnv("salesforceClientId")
+      salesforceClientSecret <- getFromEnv("salesforceClientSecret")
+      salesforceUsername <- getFromEnv("salesforceUsername")
+      salesforcePassword <- getFromEnv("salesforcePassword")
+      salesforceToken <- getFromEnv("salesforceToken")
       brazeInstanceUrl <- getFromEnv("brazeInstanceUrl")
       brazeBearerToken <- getFromEnv("brazeBearerToken")
       brazeZuoraAppId <- getFromEnv("zuoraAppIdForBraze")
       idapiInstanceUrl <- getFromEnv("idapiInstanceUrl")
       idapiBearerToken <- getFromEnv("idapiBearerToken")
     } yield Config(
+      SalesforceConfig(
+        salesforceInstanceUrl,
+        salesforceApiVersion,
+        salesforceClientId,
+        salesforceClientSecret,
+        salesforceUsername,
+        salesforcePassword,
+        salesforceToken
+      ),
       IdapiConfig(idapiInstanceUrl, idapiBearerToken),
       BrazeConfig(brazeInstanceUrl, brazeBearerToken, brazeZuoraAppId)
     )

--- a/src/main/scala/payment_failure_comms/models/Failure.scala
+++ b/src/main/scala/payment_failure_comms/models/Failure.scala
@@ -9,6 +9,14 @@ case class ConfigFailure(details: String) extends Failure {
   val kind: String = "Config"
 }
 
+case class SalesforceRequestFailure(details: String) extends Failure {
+  val kind: String = "Salesforce Request"
+}
+
+case class SalesforceResponseFailure(details: String) extends Failure {
+  val kind: String = "Salesforce Response"
+}
+
 case class IdapiRequestFailure(details: String) extends Failure {
   val kind: String = "IDAPI Request"
 }

--- a/src/main/scala/payment_failure_comms/models/PaymentFailureRecord.scala
+++ b/src/main/scala/payment_failure_comms/models/PaymentFailureRecord.scala
@@ -1,6 +1,6 @@
 package payment_failure_comms.models
 
-// TBD
+// TODO: Add actual fields to this case class
 case class PaymentFailureRecord()
 
 case class SFPaymentFailureRecordWrapper(totalSize: Int, done: Boolean, records: Seq[PaymentFailureRecord])

--- a/src/main/scala/payment_failure_comms/models/PaymentFailureRecord.scala
+++ b/src/main/scala/payment_failure_comms/models/PaymentFailureRecord.scala
@@ -1,0 +1,6 @@
+package payment_failure_comms.models
+
+// TBD
+case class PaymentFailureRecord()
+
+case class SFPaymentFailureRecordWrapper(totalSize: Int, done: Boolean, records: Seq[PaymentFailureRecord])

--- a/src/main/scala/payment_failure_comms/models/SFCompositeResponse.scala
+++ b/src/main/scala/payment_failure_comms/models/SFCompositeResponse.scala
@@ -1,0 +1,15 @@
+package payment_failure_comms.models
+
+case class SFCompositeResponse(responses: Seq[SFResponse]) {
+  lazy val hasErrors: Boolean = responses.exists(!_.success)
+  lazy val errorsAsString: Option[String] =
+    if (hasErrors) Some(s"Composite Request failed with: ${responses.map(a => a.errorAsString)}") else None
+}
+
+case class SFResponse(id: Option[String], success: Boolean, errors: Seq[SFResponseError]) {
+  def errorAsString: Option[String] = if (success) None else Some(s"Errors: ${errors.map(a => a.errorAsString)}.")
+}
+
+case class SFResponseError(statusCode: String, message: String, fields: Seq[String]) {
+  def errorAsString: String = s"statusCode: $statusCode; message: $message; fields: ${fields.mkString(", ")};"
+}

--- a/src/main/scala/payment_failure_comms/models/SFCompositeResponse.scala
+++ b/src/main/scala/payment_failure_comms/models/SFCompositeResponse.scala
@@ -3,11 +3,12 @@ package payment_failure_comms.models
 case class SFCompositeResponse(responses: Seq[SFResponse]) {
   lazy val hasErrors: Boolean = responses.exists(!_.success)
   lazy val errorsAsString: Option[String] =
-    if (hasErrors) Some(s"Composite Request failed with: ${responses.map(a => a.errorAsString)}") else None
+    if (hasErrors) Some(s"Composite Request failed with: ${responses.filter(!_.success).map(_.errorAsString)}")
+    else None
 }
 
 case class SFResponse(id: Option[String], success: Boolean, errors: Seq[SFResponseError]) {
-  def errorAsString: Option[String] = if (success) None else Some(s"Errors: ${errors.map(a => a.errorAsString)}.")
+  def errorAsString: Option[String] = if (success) None else Some(s"Errors: ${errors.map(_.errorAsString)}.")
 }
 
 case class SFResponseError(statusCode: String, message: String, fields: Seq[String]) {

--- a/src/main/scala/payment_failure_comms/models/SalesforceAuth.scala
+++ b/src/main/scala/payment_failure_comms/models/SalesforceAuth.scala
@@ -1,3 +1,4 @@
 package payment_failure_comms.models
 
+// Snake-cased for JSON marshalling
 case class SalesforceAuth(access_token: String, instance_url: String)

--- a/src/main/scala/payment_failure_comms/models/SalesforceAuth.scala
+++ b/src/main/scala/payment_failure_comms/models/SalesforceAuth.scala
@@ -1,0 +1,3 @@
+package payment_failure_comms.models
+
+case class SalesforceAuth(access_token: String, instance_url: String)

--- a/src/test/scala/payment_failure_comms/IdapiConnectorTest.scala
+++ b/src/test/scala/payment_failure_comms/IdapiConnectorTest.scala
@@ -6,7 +6,7 @@ import org.scalatest.EitherValues
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should
 import payment_failure_comms.models.{IdapiRequestFailure, IdapiResponseFailure}
-import payment_failure_comms.testData.IdapiConnectorTestData.{
+import payment_failure_comms.testData.ConnectorTestData.{
   ResponseModel,
   failureResponse,
   requestFailure,

--- a/src/test/scala/payment_failure_comms/SalesforceConnectorTest.scala
+++ b/src/test/scala/payment_failure_comms/SalesforceConnectorTest.scala
@@ -1,0 +1,48 @@
+package payment_failure_comms
+
+import io.circe.generic.auto._
+import org.scalatest.EitherValues
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should
+import payment_failure_comms.models.{SalesforceRequestFailure, SalesforceResponseFailure}
+import payment_failure_comms.testData.ConnectorTestData.{
+  ResponseModel,
+  failureResponse,
+  requestFailure,
+  successfulResponse,
+  unexpectedResponse,
+  validBodyAsClass
+}
+
+class SalesforceConnectorTest extends AnyFlatSpec with should.Matchers with EitherValues {
+
+  // handleRequestResult success cases
+  "handleRequestResult" should "return the correctly formed case class if the request was successul and the reply is 2xx" in {
+    SalesforceConnector.handleRequestResult[ResponseModel](successfulResponse) shouldBe Right(validBodyAsClass)
+  }
+
+  // handleRequestResult failure cases
+  "handleRequestResult" should "return a SalesforceRequestFailure if the request was unsuccessful" in {
+    val result = SalesforceConnector.handleRequestResult[ResponseModel](requestFailure)
+
+    result.isLeft shouldBe true
+    result.left.value shouldBe a[SalesforceRequestFailure]
+  }
+
+  "handleRequestResult" should "return a SalesforceResponseFailure if the request was successful but an error code was received " in {
+    val result = SalesforceConnector.handleRequestResult[ResponseModel](failureResponse)
+
+    result.isLeft shouldBe true
+    result.left.value shouldBe a[SalesforceResponseFailure]
+  }
+
+  "handleRequestResult" should "return a SalesforceResponseFailure if the request was successful and the reply is 2xx but the body failed decoding " in {
+    val result = SalesforceConnector.handleRequestResult[ResponseModel](unexpectedResponse)
+
+    println(result)
+
+    result.isLeft shouldBe true
+    result.left.value shouldBe a[SalesforceResponseFailure]
+  }
+
+}

--- a/src/test/scala/payment_failure_comms/testData/ConnectorTestData.scala
+++ b/src/test/scala/payment_failure_comms/testData/ConnectorTestData.scala
@@ -2,7 +2,7 @@ package payment_failure_comms.testData
 
 import okhttp3.{MediaType, Protocol, Request, Response, ResponseBody}
 
-object IdapiConnectorTestData {
+object ConnectorTestData {
 
   private val JSON: MediaType = MediaType.get("application/json; charset=utf-8")
   private val request = new Request.Builder().url("http://url").build()
@@ -13,6 +13,7 @@ object IdapiConnectorTestData {
   private val invalidBody = "{}"
 
   private val validResponseBody = ResponseBody.create(validBody, JSON)
+  private val emptyResponseBody = ResponseBody.create("", JSON)
   private val invalidResponseBody = ResponseBody.create(invalidBody, JSON)
 
   case class ResponseModel(field: Int)
@@ -36,6 +37,7 @@ object IdapiConnectorTestData {
       .protocol(Protocol.HTTP_1_1)
       .code(500)
       .message("NOT OK")
+      .body(emptyResponseBody)
       .build()
   )
 

--- a/src/test/scala/payment_failure_comms/testData/ConnectorTestData.scala
+++ b/src/test/scala/payment_failure_comms/testData/ConnectorTestData.scala
@@ -12,14 +12,14 @@ object ConnectorTestData {
   private val validBody = s"""{"field": $magicNumber}"""
   private val invalidBody = "{}"
 
-  private val validResponseBody = ResponseBody.create(validBody, JSON)
-  private val emptyResponseBody = ResponseBody.create("", JSON)
-  private val invalidResponseBody = ResponseBody.create(invalidBody, JSON)
+  private def validResponseBody = ResponseBody.create(validBody, JSON)
+  private def emptyResponseBody = ResponseBody.create("", JSON)
+  private def invalidResponseBody = ResponseBody.create(invalidBody, JSON)
 
   case class ResponseModel(field: Int)
   val validBodyAsClass = ResponseModel(32)
 
-  val successfulResponse: Either[Throwable, Response] = Right(
+  def successfulResponse: Either[Throwable, Response] = Right(
     new Response.Builder()
       .request(request)
       .protocol(Protocol.HTTP_1_1)
@@ -29,9 +29,9 @@ object ConnectorTestData {
       .build()
   )
 
-  val requestFailure: Either[Throwable, Response] = Left(new Throwable())
+  def requestFailure: Either[Throwable, Response] = Left(new Throwable())
 
-  val failureResponse: Either[Throwable, Response] = Right(
+  def failureResponse: Either[Throwable, Response] = Right(
     new Response.Builder()
       .request(request)
       .protocol(Protocol.HTTP_1_1)
@@ -41,7 +41,7 @@ object ConnectorTestData {
       .build()
   )
 
-  val unexpectedResponse: Either[Throwable, Response] = Right(
+  def unexpectedResponse: Either[Throwable, Response] = Right(
     new Response.Builder()
       .request(request)
       .protocol(Protocol.HTTP_1_1)


### PR DESCRIPTION
## What does this change?
Add a Salesforce Connector, Salesforce connection related failure classes and Salesforce secrets config/logic to the repo.

IDAPI test data was moved into more abstract object so it can be unit by any Connector's uni tests.