### PR TITLE
Fixes and tweaks

### DIFF
--- a/cfn.yaml
+++ b/cfn.yaml
@@ -118,7 +118,7 @@ Resources:
               SalesforceUsername: !FindInMap [ StageMap, !Ref Stage, SalesforceUsername ]
           idapiInstanceUrl: !FindInMap [ StageMap, !Ref Stage, IdapiInstanceUrl ]
           idapiBearerToken: !Sub
-            - '{{resolve:secretsmanager:IDAPI/${IDAPIStage}/${AppName}:SecretString:bearerToken::${IDAPISecretsVersion}}}'
+            - '{{resolve:secretsmanager:IDAPI/${IdapiStage}/${AppName}:SecretString:bearerToken::${IdapiSecretsVersion}}}'
             - IdapiStage: !FindInMap [ StageMap, !Ref Stage, IdapiStage ]
               IdapiSecretsVersion: !FindInMap [ StageMap, !Ref Stage, IdapiSecretsVersion ]
           brazeInstanceUrl: !FindInMap [ StageMap, !Ref Stage, BrazeInstanceUrl ]

--- a/src/main/scala/payment_failure_comms/BrazeConnector.scala
+++ b/src/main/scala/payment_failure_comms/BrazeConnector.scala
@@ -36,13 +36,15 @@ object BrazeConnector {
   def handleRequestResult(result: Either[Throwable, Response]): Either[Failure, Unit] = {
     result
       .left.map(i => BrazeRequestFailure(s"Attempt to contact Braze failed with error: ${i.toString}"))
-      .flatMap(response =>
+      .flatMap(response => {
+        val body = response.body().string()
+
         if (response.isSuccessful) {
           Right(())
         } else {
-          Left(BrazeResponseFailure(s"The request to Braze was unsuccessful: ${response.code} - ${response.body}"))
+          Left(BrazeResponseFailure(s"The request to Braze was unsuccessful: ${response.code} - ${body}"))
         }
-      )
+      })
   }
 
 }

--- a/src/main/scala/payment_failure_comms/Handler.scala
+++ b/src/main/scala/payment_failure_comms/Handler.scala
@@ -8,8 +8,8 @@ object Handler {
     (for {
       config <- Config()
     } yield ()) match {
-      case Left(_)  => println("Success")
-      case Right(_) => println("I totally just ran.")
+      case Left(failure) => println(failure)
+      case Right(_)      => println("I totally just ran.")
     }
   }
 

--- a/src/main/scala/payment_failure_comms/Handler.scala
+++ b/src/main/scala/payment_failure_comms/Handler.scala
@@ -1,7 +1,16 @@
 package payment_failure_comms
 
+import payment_failure_comms.models.Config
+
 object Handler {
+
   def handleRequest(): Unit = {
-    println("I totally just ran.")
+    (for {
+      config <- Config()
+    } yield ()) match {
+      case Left(_)  => println("Success")
+      case Right(_) => println("I totally just ran.")
+    }
   }
+
 }

--- a/src/main/scala/payment_failure_comms/IdapiConnector.scala
+++ b/src/main/scala/payment_failure_comms/IdapiConnector.scala
@@ -18,7 +18,7 @@ object IdapiConnector {
   private val http = new OkHttpClient()
 
   def getBrazeId(idapiConfig: IdapiConfig, IdentityId: String): Either[Failure, String] = {
-    handleRequestResponse[IdapiGetUserResponse](
+    handleRequestResult[IdapiGetUserResponse](
       getRequest(
         url = s"https://${idapiConfig.instanceUrl}/users/track",
         bearerToken = idapiConfig.bearerToken
@@ -37,7 +37,7 @@ object IdapiConnector {
     ).toEither
   }
 
-  def handleRequestResponse[T: Decoder](result: Either[Throwable, Response]): Either[Failure, T] = {
+  def handleRequestResult[T: Decoder](result: Either[Throwable, Response]): Either[Failure, T] = {
     result
       .left.map(i => IdapiRequestFailure(s"Attempt to contact Braze failed with error: ${i.toString}"))
       .flatMap(response =>

--- a/src/main/scala/payment_failure_comms/IdapiConnector.scala
+++ b/src/main/scala/payment_failure_comms/IdapiConnector.scala
@@ -40,17 +40,17 @@ object IdapiConnector {
   def handleRequestResult[T: Decoder](result: Either[Throwable, Response]): Either[Failure, T] = {
     result
       .left.map(i => IdapiRequestFailure(s"Attempt to contact Braze failed with error: ${i.toString}"))
-      .flatMap(response =>
+      .flatMap(response => {
+        val body = response.body().string()
+
         if (response.isSuccessful) {
-          decode[T](response.body().string())
+          decode[T](body)
             .left.map(decodeError =>
-              IdapiResponseFailure(
-                s"Failed to decode successful response:$decodeError. Body to decode ${response.body().string()}"
-              )
+              IdapiResponseFailure(s"Failed to decode successful response:$decodeError. Body to decode ${body}")
             )
         } else {
-          Left(IdapiResponseFailure(s"The request to Braze was unsuccessful: ${response.code} - ${response.body}"))
+          Left(IdapiResponseFailure(s"The request to Braze was unsuccessful: ${response.code} - ${body}"))
         }
-      )
+      })
   }
 }

--- a/src/main/scala/payment_failure_comms/SalesforceConnector.scala
+++ b/src/main/scala/payment_failure_comms/SalesforceConnector.scala
@@ -136,25 +136,18 @@ object SalesforceConnector {
   def handleRequestResult[T: Decoder](result: Either[Throwable, Response]): Either[Failure, T] = {
     result
       .left.map(i => SalesforceRequestFailure(s"Attempt to contact Salesforce failed with error: ${i.toString}"))
-      .flatMap { response =>
+      .flatMap(response => {
         val body = response.body().string()
 
         if (response.isSuccessful) {
-
           decode[T](body)
             .left.map(decodeError =>
-              SalesforceResponseFailure(
-                s"Failed to decode successful response:$decodeError. Body to decode ${body}"
-              )
+              SalesforceResponseFailure(s"Failed to decode successful response:$decodeError. Body to decode ${body}")
             )
         } else {
-          Left(
-            SalesforceResponseFailure(
-              s"The request to Salesforce was unsuccessful: ${response.code} - ${body}"
-            )
-          )
+          Left(SalesforceResponseFailure(s"The request to Salesforce was unsuccessful: ${response.code} - ${body}"))
         }
-      }
+      })
   }
 
 }

--- a/src/main/scala/payment_failure_comms/SalesforceConnector.scala
+++ b/src/main/scala/payment_failure_comms/SalesforceConnector.scala
@@ -16,7 +16,6 @@ import payment_failure_comms.models.{
   SalesforceRequestFailure,
   SalesforceResponseFailure
 }
-
 import scala.util.Try
 
 case class PaymentFailureRecordUpdate()

--- a/src/test/scala/payment_failure_comms/IdapiConnectorTest.scala
+++ b/src/test/scala/payment_failure_comms/IdapiConnectorTest.scala
@@ -15,30 +15,30 @@ import payment_failure_comms.testData.ConnectorTestData.{
   validBodyAsClass
 }
 
-class IdentityConnectorTests extends AnyFlatSpec with should.Matchers with EitherValues {
+class IdapiConnectorTests extends AnyFlatSpec with should.Matchers with EitherValues {
 
-  // handleRequestResponse success cases
-  "handleRequestResponse" should "return the corrrectly formed case class if the request was successul and the reply is 2xx" in {
-    IdapiConnector.handleRequestResponse[ResponseModel](successfulResponse) shouldBe Right(validBodyAsClass)
+  // handleRequestResult success cases
+  "handleRequestResult" should "return the corrrectly formed case class if the request was successul and the reply is 2xx" in {
+    IdapiConnector.handleRequestResult[ResponseModel](successfulResponse) shouldBe Right(validBodyAsClass)
   }
 
-  // handleRequestResponse failure cases
-  "handleRequestResponse" should "return an IdapiRequestFailure if the request was unsuccessful" in {
-    val result = IdapiConnector.handleRequestResponse[ResponseModel](requestFailure)
+  // handleRequestResult failure cases
+  "handleRequestResult" should "return an IdapiRequestFailure if the request was unsuccessful" in {
+    val result = IdapiConnector.handleRequestResult[ResponseModel](requestFailure)
 
     result.isLeft shouldBe true
     result.left.value shouldBe a[IdapiRequestFailure]
   }
 
-  "handleRequestResponse" should "return an IdapiResponseFailure if the request was successful but an error code was received " in {
-    val result = IdapiConnector.handleRequestResponse[ResponseModel](failureResponse)
+  "handleRequestResult" should "return an IdapiResponseFailure if the request was successful but an error code was received " in {
+    val result = IdapiConnector.handleRequestResult[ResponseModel](failureResponse)
 
     result.isLeft shouldBe true
     result.left.value shouldBe a[IdapiResponseFailure]
   }
 
-  "handleRequestResponse" should "return an IdapiResponseFailure if the request was successful and the reply is 2xx but the body failed decoding " in {
-    val result = IdapiConnector.handleRequestResponse[ResponseModel](unexpectedResponse)
+  "handleRequestResult" should "return an IdapiResponseFailure if the request was successful and the reply is 2xx but the body failed decoding " in {
+    val result = IdapiConnector.handleRequestResult[ResponseModel](unexpectedResponse)
 
     result.isLeft shouldBe true
     result.left.value shouldBe a[IdapiResponseFailure]

--- a/src/test/scala/payment_failure_comms/IdapiConnectorTest.scala
+++ b/src/test/scala/payment_failure_comms/IdapiConnectorTest.scala
@@ -1,7 +1,6 @@
 package payment_failure_comms
 
 import io.circe.generic.auto._
-import okhttp3.{MediaType, Request, Response, ResponseBody}
 import org.scalatest.EitherValues
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should

--- a/src/test/scala/payment_failure_comms/testData/ConnectorTestData.scala
+++ b/src/test/scala/payment_failure_comms/testData/ConnectorTestData.scala
@@ -17,7 +17,7 @@ object ConnectorTestData {
   private def invalidResponseBody = ResponseBody.create(invalidBody, JSON)
 
   case class ResponseModel(field: Int)
-  val validBodyAsClass = ResponseModel(32)
+  val validBodyAsClass = ResponseModel(magicNumber)
 
   def successfulResponse: Either[Throwable, Response] = Right(
     new Response.Builder()


### PR DESCRIPTION
## What does this change?
Makes a number of small fixes to the code and standardises some pieces of logic and variable names across the codebase.

Summary:

- Standardises Connector related language used
- Fixes issue with getting the body from `ResponseBody` (`.body().string()` can only be used once)
- Fixes IDAPI related variable names in CloudFormation 
- Alters the handler to enable testing of the environment variables
- Improvements to consistency in the code base