### PR TITLE
Core logic

### DIFF
--- a/src/main/scala/payment_failure_comms/Handler.scala
+++ b/src/main/scala/payment_failure_comms/Handler.scala
@@ -6,6 +6,7 @@ import payment_failure_comms.models.{
   Failure,
   IdapiConfig,
   PaymentFailureRecord,
+  PaymentFailureRecordUpdateRequest,
   PaymentFailureRecordWithBrazeId
 }
 
@@ -21,6 +22,12 @@ object Handler {
 
       brazeRequest = BrazeTrackRequest(recordsWithBrazeId, config.braze.zuoraAppId)
       brazeResult = BrazeConnector.sendCustomEvent(config.braze, brazeRequest)
+
+      updateRecordsRequest = PaymentFailureRecordUpdateRequest(recordsWithBrazeId, brazeResult)
+      updateRecordsResult <- sfConnector.updateRecords(updateRecordsRequest)
+
+      // TODO: Process updateRecordsResult for eventual failures
+
     } yield ()) match {
       case Left(failure) => println(failure)
       case Right(_)      => println("I totally just ran.")

--- a/src/main/scala/payment_failure_comms/Handler.scala
+++ b/src/main/scala/payment_failure_comms/Handler.scala
@@ -1,6 +1,12 @@
 package payment_failure_comms
 
-import payment_failure_comms.models.Config
+import payment_failure_comms.models.{
+  Config,
+  Failure,
+  IdapiConfig,
+  PaymentFailureRecord,
+  PaymentFailureRecordWithBrazeId
+}
 
 object Handler {
 
@@ -9,10 +15,24 @@ object Handler {
       config <- Config()
       sfConnector <- SalesforceConnector(config.salesforce)
       records <- sfConnector.getRecordsToProcess()
+      recordsWithBrazeId = augmentRecords(config.idapi, records)
+
     } yield ()) match {
       case Left(failure) => println(failure)
       case Right(_)      => println("I totally just ran.")
     }
+  }
+
+  def augmentRecords(
+      idapiConfig: IdapiConfig,
+      records: Seq[PaymentFailureRecord]
+  ): Seq[PaymentFailureRecordWithBrazeId] = {
+    records.map(record =>
+      PaymentFailureRecordWithBrazeId(
+        record,
+        IdapiConnector.getBrazeId(idapiConfig, record.Contact__r.IdentityID__c)
+      )
+    )
   }
 
 }

--- a/src/main/scala/payment_failure_comms/Handler.scala
+++ b/src/main/scala/payment_failure_comms/Handler.scala
@@ -1,6 +1,7 @@
 package payment_failure_comms
 
 import payment_failure_comms.models.{
+  BrazeTrackRequest,
   Config,
   Failure,
   IdapiConfig,
@@ -14,9 +15,12 @@ object Handler {
     (for {
       config <- Config()
       sfConnector <- SalesforceConnector(config.salesforce)
+
       records <- sfConnector.getRecordsToProcess()
       recordsWithBrazeId = augmentRecords(config.idapi, records)
 
+      brazeRequest = BrazeTrackRequest(recordsWithBrazeId, config.braze.zuoraAppId)
+      brazeResult = BrazeConnector.sendCustomEvent(config.braze, brazeRequest)
     } yield ()) match {
       case Left(failure) => println(failure)
       case Right(_)      => println("I totally just ran.")

--- a/src/main/scala/payment_failure_comms/Handler.scala
+++ b/src/main/scala/payment_failure_comms/Handler.scala
@@ -7,6 +7,8 @@ object Handler {
   def handleRequest(): Unit = {
     (for {
       config <- Config()
+      sfConnector <- SalesforceConnector(config.salesforce)
+      records <- sfConnector.getRecordsToProcess()
     } yield ()) match {
       case Left(failure) => println(failure)
       case Right(_)      => println("I totally just ran.")

--- a/src/main/scala/payment_failure_comms/SalesforceConnector.scala
+++ b/src/main/scala/payment_failure_comms/SalesforceConnector.scala
@@ -49,8 +49,11 @@ object SalesforceConnector {
       authDetails: SalesforceAuth,
       apiVersion: String
   ): Either[Failure, Seq[PaymentFailureRecord]] = {
-    // TODO: Replace with actual query
-    val query = "TBD"
+    val query = """
+        |SELECT Id, Status__c, Contact__r.IdentityID__c, PF_Comms_Number_of_Attempts__c
+        |FROM Payment_Failure__c
+        |WHERE PF_Comms_Status__c In ('', 'Ready to process exit','Ready to process entry')
+        |LIMIT 200""".stripMargin
 
     handleRequestResult[SFPaymentFailureRecordWrapper](
       queryRequest(

--- a/src/main/scala/payment_failure_comms/SalesforceConnector.scala
+++ b/src/main/scala/payment_failure_comms/SalesforceConnector.scala
@@ -8,6 +8,7 @@ import okhttp3.{HttpUrl, MediaType, OkHttpClient, Request, RequestBody, Response
 import payment_failure_comms.models.{
   Failure,
   PaymentFailureRecord,
+  PaymentFailureRecordUpdateRequest,
   SFCompositeResponse,
   SFPaymentFailureRecordWrapper,
   SFResponse,
@@ -16,16 +17,15 @@ import payment_failure_comms.models.{
   SalesforceRequestFailure,
   SalesforceResponseFailure
 }
-import scala.util.Try
 
-case class PaymentFailureRecordUpdate()
+import scala.util.Try
 
 class SalesforceConnector(authDetails: SalesforceAuth, apiVersion: String) {
   def getRecordsToProcess(): Either[Failure, Seq[PaymentFailureRecord]] =
     SalesforceConnector.getRecordsToProcess(authDetails, apiVersion)
 
-  def updateRecords(records: Seq[PaymentFailureRecordUpdate]): Either[Failure, SFCompositeResponse] =
-    SalesforceConnector.updateRecords(authDetails, apiVersion, records)
+  def updateRecords(request: PaymentFailureRecordUpdateRequest): Either[Failure, SFCompositeResponse] =
+    SalesforceConnector.updateRecords(authDetails, apiVersion, request)
 }
 
 object SalesforceConnector {
@@ -49,11 +49,16 @@ object SalesforceConnector {
       authDetails: SalesforceAuth,
       apiVersion: String
   ): Either[Failure, Seq[PaymentFailureRecord]] = {
-    val query = """
-        |SELECT Id, Status__c, Contact__r.IdentityID__c, PF_Comms_Number_of_Attempts__c
-        |FROM Payment_Failure__c
-        |WHERE PF_Comms_Status__c In ('', 'Ready to process exit','Ready to process entry')
-        |LIMIT 200""".stripMargin
+    val query =
+      """
+      |SELECT Id,
+      |   Status__c,
+      |   Contact__r.IdentityID__c,
+      |   PF_Comms_Last_Stage_Processed__c, 
+      |   PF_Comms_Number_of_Attempts__c
+      |FROM Payment_Failure__c
+      |WHERE PF_Comms_Status__c In ('', 'Ready to process exit','Ready to process entry')
+      |LIMIT 200""".stripMargin
 
     handleRequestResult[SFPaymentFailureRecordWrapper](
       queryRequest(
@@ -68,9 +73,9 @@ object SalesforceConnector {
   def updateRecords(
       authDetails: SalesforceAuth,
       apiVersion: String,
-      records: Seq[PaymentFailureRecordUpdate]
+      request: PaymentFailureRecordUpdateRequest
   ): Either[Failure, SFCompositeResponse] = {
-    val body = RequestBody.create(records.asJson.toString, JSON)
+    val body = RequestBody.create(request.asJson.toString, JSON)
 
     handleRequestResult[Seq[SFResponse]](
       compositeRequest(

--- a/src/main/scala/payment_failure_comms/SalesforceConnector.scala
+++ b/src/main/scala/payment_failure_comms/SalesforceConnector.scala
@@ -55,7 +55,9 @@ object SalesforceConnector {
       |   Status__c,
       |   Contact__r.IdentityID__c,
       |   PF_Comms_Last_Stage_Processed__c, 
-      |   PF_Comms_Number_of_Attempts__c
+      |   PF_Comms_Number_of_Attempts__c,
+      |   Currency__c,
+      |   Invoice_Total_Amount__c
       |FROM Payment_Failure__c
       |WHERE PF_Comms_Status__c In ('', 'Ready to process exit','Ready to process entry')
       |LIMIT 200""".stripMargin

--- a/src/main/scala/payment_failure_comms/models/PaymentFailureRecord.scala
+++ b/src/main/scala/payment_failure_comms/models/PaymentFailureRecord.scala
@@ -5,7 +5,9 @@ case class PaymentFailureRecord(
     Contact__r: SFContact,
     Status__c: String,
     PF_Comms_Last_Stage_Processed__c: Option[String] = None,
-    PF_Comms_Number_of_Attempts__c: Option[Int] = Some(0)
+    PF_Comms_Number_of_Attempts__c: Option[Int] = Some(0),
+    Currency__c: String,
+    Invoice_Total_Amount__c: Double
 )
 
 case class SFContact(IdentityID__c: String)

--- a/src/main/scala/payment_failure_comms/models/PaymentFailureRecord.scala
+++ b/src/main/scala/payment_failure_comms/models/PaymentFailureRecord.scala
@@ -4,7 +4,8 @@ case class PaymentFailureRecord(
     Id: String,
     Contact__r: SFContact,
     Status__c: String,
-    PF_Comms_Number_of_Attempts__c: Option[Int] = None
+    PF_Comms_Last_Stage_Processed__c: Option[String] = None,
+    PF_Comms_Number_of_Attempts__c: Option[Int] = Some(0)
 )
 
 case class SFContact(IdentityID__c: String)

--- a/src/main/scala/payment_failure_comms/models/PaymentFailureRecord.scala
+++ b/src/main/scala/payment_failure_comms/models/PaymentFailureRecord.scala
@@ -1,6 +1,12 @@
 package payment_failure_comms.models
 
-// TODO: Add actual fields to this case class
-case class PaymentFailureRecord()
+case class PaymentFailureRecord(
+    Id: String,
+    Contact__r: SFContact,
+    Status__c: String,
+    PF_Comms_Number_of_Attempts__c: Option[Int] = None
+)
+
+case class SFContact(IdentityID__c: String)
 
 case class SFPaymentFailureRecordWrapper(totalSize: Int, done: Boolean, records: Seq[PaymentFailureRecord])

--- a/src/main/scala/payment_failure_comms/models/PaymentFailureRecordUpdate.scala
+++ b/src/main/scala/payment_failure_comms/models/PaymentFailureRecordUpdate.scala
@@ -1,0 +1,62 @@
+package payment_failure_comms.models
+
+case class PaymentFailureRecordUpdate(
+    Id: String,
+    PF_Comms_Last_Stage_Processed__c: Option[String] = None,
+    PF_Comms_Number_of_Attempts__c: Int,
+    attributes: Attributes = Attributes(`type` = "Payment_Failure__c")
+)
+
+case class Attributes(`type`: String)
+
+case class PaymentFailureRecordUpdateRequest(records: Seq[PaymentFailureRecordUpdate]) {
+  def allOrNone = false
+}
+
+object PaymentFailureRecordUpdate {
+
+  val eventStageMapping = Map(
+    "In Progress" -> "Entry",
+    "Recovered" -> "Exit",
+    "Auto-Cancel Failure" -> "Exit",
+    "Already Cancelled" -> "Exit"
+  )
+
+  def apply(
+      record: PaymentFailureRecordWithBrazeId,
+      brazeResult: Either[Failure, Unit]
+  ): PaymentFailureRecordUpdate = {
+    brazeResult match {
+      case Right(_) => successfulUpdate(record)
+      case Left(_)  => failedUpdate(record)
+    }
+  }
+
+  def successfulUpdate(augmentedRecord: PaymentFailureRecordWithBrazeId) = {
+    PaymentFailureRecordUpdate(
+      augmentedRecord.record.Id,
+      eventStageMapping.get(augmentedRecord.record.Status__c),
+      0
+    )
+  }
+
+  def failedUpdate(augmentedRecord: PaymentFailureRecordWithBrazeId) = {
+    PaymentFailureRecordUpdate(
+      augmentedRecord.record.Id,
+      augmentedRecord.record.PF_Comms_Last_Stage_Processed__c,
+      augmentedRecord.record.PF_Comms_Number_of_Attempts__c.getOrElse(0) + 1
+    )
+  }
+}
+
+object PaymentFailureRecordUpdateRequest {
+  def apply(
+      augmentedRecords: Seq[PaymentFailureRecordWithBrazeId],
+      brazeResult: Either[Failure, Unit]
+  ): PaymentFailureRecordUpdateRequest = {
+    PaymentFailureRecordUpdateRequest(
+      augmentedRecords
+        .map(PaymentFailureRecordUpdate(_, brazeResult))
+    )
+  }
+}

--- a/src/main/scala/payment_failure_comms/models/PaymentFailureRecordWithBrazeId.scala
+++ b/src/main/scala/payment_failure_comms/models/PaymentFailureRecordWithBrazeId.scala
@@ -1,0 +1,3 @@
+package payment_failure_comms.models
+
+case class PaymentFailureRecordWithBrazeId(record: PaymentFailureRecord, brazeId: Either[Failure, String])

--- a/src/main/scala/payment_failure_comms/models/brazeTrackEvents.scala
+++ b/src/main/scala/payment_failure_comms/models/brazeTrackEvents.scala
@@ -28,8 +28,10 @@ object BrazeTrackRequest {
         val eventName = eventNameMapping.getOrElse(record.record.Status__c, "")
         // TODO: Determine eventTime from record. Entry and exit events will fetch date from different fields
         val eventTime = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss:SSSZ").format(ZonedDateTime.now)
-        // TODO: Determine eventProperties from record
-        val eventProperties = EventProperties("EUR", 0.00)
+        val eventProperties = EventProperties(
+          currency = record.record.Currency__c,
+          amount = record.record.Invoice_Total_Amount__c
+        )
 
         CustomEvent(
           external_id = record.brazeId.getOrElse(""), // The OrElse never happens because it's filtered out above

--- a/src/main/scala/payment_failure_comms/models/brazeTrackEvents.scala
+++ b/src/main/scala/payment_failure_comms/models/brazeTrackEvents.scala
@@ -3,9 +3,44 @@ package payment_failure_comms.models
 import java.time.format.DateTimeFormatter
 import java.time.ZonedDateTime
 
-case class BrazeTrackRequest(events: List[CustomEvent])
+case class BrazeTrackRequest(events: Seq[CustomEvent])
 
 // Based on https://www.braze.com/docs/api/objects_filters/event_object/
 case class CustomEvent(external_id: String, app_id: String, name: String, time: String, properties: EventProperties)
 
 case class EventProperties(currency: String, amount: Double)
+
+object BrazeTrackRequest {
+
+  val eventNameMapping = Map(
+    "In Progress" -> "payment_failure",
+    "Recovered" -> "payment_recovery",
+    "Auto-Cancel Failure" -> "payment_failure_cancelation",
+    "Already Cancelled" -> "subscription_cancelation"
+  )
+
+  def apply(records: Seq[PaymentFailureRecordWithBrazeId], zuoraAppId: String): BrazeTrackRequest = {
+
+    val events = records
+      .filter(_.brazeId.isRight)
+      .map(record => {
+        // TODO: Throw error if record.record.Status__c doesn't exist in eventNameMapping
+        val eventName = eventNameMapping.getOrElse(record.record.Status__c, "")
+        // TODO: Determine eventTime from record. Entry and exit events will fetch date from different fields
+        val eventTime = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss:SSSZ").format(ZonedDateTime.now)
+        // TODO: Determine eventProperties from record
+        val eventProperties = EventProperties("EUR", 0.00)
+
+        CustomEvent(
+          external_id = record.brazeId.getOrElse(""), // The OrElse never happens because it's filtered out above
+          app_id = zuoraAppId,
+          name = eventName,
+          time = eventTime,
+          properties = eventProperties
+        )
+      })
+
+    BrazeTrackRequest(events)
+  }
+
+}

--- a/src/test/scala/payment_failure_comms/BrazeConnectorTests.scala
+++ b/src/test/scala/payment_failure_comms/BrazeConnectorTests.scala
@@ -21,7 +21,7 @@ class BrazeConnectorTests extends AnyFlatSpec with should.Matchers with EitherVa
     result.left.value shouldBe a[BrazeRequestFailure]
   }
 
-  "handleRequestResult" should "return a BrazeResponseFailure if the request was successful but an error code was received " in {
+  "handleRequestResult" should "return a BrazeResponseFailure if the request was successful but an error code was received" in {
     val result = BrazeConnector.handleRequestResult(failureResponse)
 
     result.isLeft shouldBe true

--- a/src/test/scala/payment_failure_comms/IdapiConnectorTests.scala
+++ b/src/test/scala/payment_failure_comms/IdapiConnectorTests.scala
@@ -29,14 +29,14 @@ class IdapiConnectorTests extends AnyFlatSpec with should.Matchers with EitherVa
     result.left.value shouldBe a[IdapiRequestFailure]
   }
 
-  "handleRequestResult" should "return an IdapiResponseFailure if the request was successful but an error code was received " in {
+  "handleRequestResult" should "return an IdapiResponseFailure if the request was successful but an error code was received" in {
     val result = IdapiConnector.handleRequestResult[ResponseModel](failureResponse)
 
     result.isLeft shouldBe true
     result.left.value shouldBe a[IdapiResponseFailure]
   }
 
-  "handleRequestResult" should "return an IdapiResponseFailure if the request was successful and the reply is 2xx but the body failed decoding " in {
+  "handleRequestResult" should "return an IdapiResponseFailure if the request was successful and the reply is 2xx but the body failed decoding" in {
     val result = IdapiConnector.handleRequestResult[ResponseModel](unexpectedResponse)
 
     result.isLeft shouldBe true

--- a/src/test/scala/payment_failure_comms/SalesforceConnectorTests.scala
+++ b/src/test/scala/payment_failure_comms/SalesforceConnectorTests.scala
@@ -29,14 +29,14 @@ class SalesforceConnectorTests extends AnyFlatSpec with should.Matchers with Eit
     result.left.value shouldBe a[SalesforceRequestFailure]
   }
 
-  "handleRequestResult" should "return a SalesforceResponseFailure if the request was successful but an error code was received " in {
+  "handleRequestResult" should "return a SalesforceResponseFailure if the request was successful but an error code was received" in {
     val result = SalesforceConnector.handleRequestResult[ResponseModel](failureResponse)
 
     result.isLeft shouldBe true
     result.left.value shouldBe a[SalesforceResponseFailure]
   }
 
-  "handleRequestResult" should "return a SalesforceResponseFailure if the request was successful and the reply is 2xx but the body failed decoding " in {
+  "handleRequestResult" should "return a SalesforceResponseFailure if the request was successful and the reply is 2xx but the body failed decoding" in {
     val result = SalesforceConnector.handleRequestResult[ResponseModel](unexpectedResponse)
 
     println(result)

--- a/src/test/scala/payment_failure_comms/SalesforceConnectorTests.scala
+++ b/src/test/scala/payment_failure_comms/SalesforceConnectorTests.scala
@@ -39,8 +39,6 @@ class SalesforceConnectorTests extends AnyFlatSpec with should.Matchers with Eit
   "handleRequestResult" should "return a SalesforceResponseFailure if the request was successful and the reply is 2xx but the body failed decoding" in {
     val result = SalesforceConnector.handleRequestResult[ResponseModel](unexpectedResponse)
 
-    println(result)
-
     result.isLeft shouldBe true
     result.left.value shouldBe a[SalesforceResponseFailure]
   }


### PR DESCRIPTION
Adds the core logic to payment failure comms, which is:
- Fetch records that need processing from Salesforce
- Fetch braze ID from IDAPI for each record
- Insert records as Custom Events into Braze
- Update records in Salesforce to mark them as processed