### PR TITLE
Set Riff Raff AWS Region

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,6 +6,7 @@ lazy val root = (project in file("."))
   .settings(
     name := "payment-failure-comms",
     assemblyJarName := s"${name.value}.jar",
+    riffRaffAwsRegion := "eu-west-1",
     riffRaffPackageType := assembly.value,
     riffRaffUploadArtifactBucket := Option("riffraff-artifact"),
     riffRaffUploadManifestBucket := Option("riffraff-builds"),


### PR DESCRIPTION
## What does this change?
Sets the Riff Raff AWS Region. This is needed following an update, to avoid an error when running sbt.