### PR TITLE
Add Product to the Custom Event Properties

### DIFF
--- a/src/main/scala/payment_failure_comms/SalesforceConnector.scala
+++ b/src/main/scala/payment_failure_comms/SalesforceConnector.scala
@@ -55,6 +55,7 @@ object SalesforceConnector {
       |SELECT Id,
       |   Status__c,
       |   Contact__r.IdentityID__c,
+      |   SF_Subscription__r.Product_Name__c,
       |   PF_Comms_Last_Stage_Processed__c, 
       |   PF_Comms_Number_of_Attempts__c,
       |   Currency__c,

--- a/src/main/scala/payment_failure_comms/models/PaymentFailureRecord.scala
+++ b/src/main/scala/payment_failure_comms/models/PaymentFailureRecord.scala
@@ -3,6 +3,7 @@ package payment_failure_comms.models
 case class PaymentFailureRecord(
     Id: String,
     Contact__r: SFContact,
+    SF_Subscription__r: SFSubscription,
     Status__c: String,
     PF_Comms_Last_Stage_Processed__c: Option[String] = None,
     PF_Comms_Number_of_Attempts__c: Option[Int] = Some(0),
@@ -11,5 +12,7 @@ case class PaymentFailureRecord(
 )
 
 case class SFContact(IdentityID__c: String)
+
+case class SFSubscription(Product_Name__c: String)
 
 case class SFPaymentFailureRecordWrapper(totalSize: Int, done: Boolean, records: Seq[PaymentFailureRecord])

--- a/src/main/scala/payment_failure_comms/models/brazeTrackEvents.scala
+++ b/src/main/scala/payment_failure_comms/models/brazeTrackEvents.scala
@@ -8,7 +8,7 @@ case class BrazeTrackRequest(events: Seq[CustomEvent])
 // Based on https://www.braze.com/docs/api/objects_filters/event_object/
 case class CustomEvent(external_id: String, app_id: String, name: String, time: String, properties: EventProperties)
 
-case class EventProperties(currency: String, amount: Double)
+case class EventProperties(product: String, currency: String, amount: Double)
 
 object BrazeTrackRequest {
 
@@ -31,6 +31,7 @@ object BrazeTrackRequest {
         // TODO: Determine eventTime from record. Entry and exit events will fetch date from different fields
         val eventTime = dateTimeFormatter.format(ZonedDateTime.now)
         val eventProperties = EventProperties(
+          product = record.record.SF_Subscription__r.Product_Name__c,
           currency = record.record.Currency__c,
           amount = record.record.Invoice_Total_Amount__c
         )


### PR DESCRIPTION
## What does this change?
Adds `product` to the properties on the Braze Custom Event. This will allow configuring the canvas to segment based on the product that is in payment failure.