### PR TITLE
Make handler runnable in standalone app

### DIFF
--- a/src/main/scala/payment_failure_comms/Handler.scala
+++ b/src/main/scala/payment_failure_comms/Handler.scala
@@ -10,7 +10,7 @@ import payment_failure_comms.models.{
   PaymentFailureRecordWithBrazeId
 }
 
-object Handler {
+object Handler extends App {
 
   def handleRequest(): Unit = {
     (for {
@@ -34,7 +34,7 @@ object Handler {
     }
   }
 
-  def augmentRecords(
+  private def augmentRecords(
       idapiConfig: IdapiConfig,
       records: Seq[PaymentFailureRecord]
   ): Seq[PaymentFailureRecordWithBrazeId] = {
@@ -46,4 +46,5 @@ object Handler {
     )
   }
 
+  handleRequest()
 }


### PR DESCRIPTION
Make it easier to do a functional test on a dev machine by making the Handler dual-purpose so that it can run in a lambda and standalone.