### PR TITLE
Fix writing back to Salesforce and refactor

### DIFF
--- a/src/main/scala/payment_failure_comms/BrazeConnector.scala
+++ b/src/main/scala/payment_failure_comms/BrazeConnector.scala
@@ -11,7 +11,7 @@ object BrazeConnector {
   private val JSON: MediaType = MediaType.get("application/json; charset=utf-8")
   private val http = new OkHttpClient()
 
-  def sendCustomEvent(brazeConfig: BrazeConfig, payload: BrazeTrackRequest): Either[Failure, Unit] = {
+  def sendCustomEvents(brazeConfig: BrazeConfig, payload: BrazeTrackRequest): Either[Failure, Unit] = {
     if (payload.events.isEmpty)
       Right(())
     else

--- a/src/main/scala/payment_failure_comms/Handler.scala
+++ b/src/main/scala/payment_failure_comms/Handler.scala
@@ -37,13 +37,10 @@ object Handler {
   def augmentRecords(
       idapiConfig: IdapiConfig,
       records: Seq[PaymentFailureRecord]
-  ): Seq[PaymentFailureRecordWithBrazeId] = {
-    records.map(record =>
-      PaymentFailureRecordWithBrazeId(
-        record,
-        IdapiConnector.getBrazeId(idapiConfig, record.Contact__r.IdentityID__c)
-      )
-    )
-  }
+  ): Seq[PaymentFailureRecordWithBrazeId] =
+    for {
+      record <- records
+      brazeId <- IdapiConnector.getBrazeId(idapiConfig, record.Contact__r.IdentityID__c).toSeq
+    } yield PaymentFailureRecordWithBrazeId(record, brazeId)
 
 }

--- a/src/main/scala/payment_failure_comms/models/PaymentFailureRecordWithBrazeId.scala
+++ b/src/main/scala/payment_failure_comms/models/PaymentFailureRecordWithBrazeId.scala
@@ -1,3 +1,3 @@
 package payment_failure_comms.models
 
-case class PaymentFailureRecordWithBrazeId(record: PaymentFailureRecord, brazeId: Either[Failure, String])
+case class PaymentFailureRecordWithBrazeId(record: PaymentFailureRecord, brazeId: String)

--- a/src/main/scala/payment_failure_comms/models/brazeTrackEvents.scala
+++ b/src/main/scala/payment_failure_comms/models/brazeTrackEvents.scala
@@ -23,7 +23,6 @@ object BrazeTrackRequest {
   def apply(records: Seq[PaymentFailureRecordWithBrazeId], zuoraAppId: String): BrazeTrackRequest = {
 
     val events = records
-      .filter(_.brazeId.isRight)
       .map(record => {
         // TODO: Consider handling case when record.record.Status__c doesn't exist in eventNameMapping differently,
         // despite it not being a realistic possibility (Possible contents of field need to be altered in Salesforce for that to happen)
@@ -36,7 +35,7 @@ object BrazeTrackRequest {
         )
 
         CustomEvent(
-          external_id = record.brazeId.getOrElse(""), // The OrElse never happens because it's filtered out above
+          external_id = record.brazeId,
           app_id = zuoraAppId,
           name = eventName,
           time = eventTime,


### PR DESCRIPTION
This change fixes a bug where payment-failure records that had no matching Braze ID were being written back to Salesforce as successes.  It also does some refactoring of some of the processing to keep a clear distinction between the two types of record: those with a Braze ID and those without.

There will be an improvement following, to log cases where Idapi fails.
