### PR TITLE
Log main events

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,10 +14,11 @@ lazy val root = (project in file("."))
     riffRaffArtifactResources += (file("cfn.yaml"), "cfn/cfn.yaml"),
     libraryDependencies ++=
       Seq(
-        "org.scalatest" %% "scalatest" % "3.2.10" % Test,
+        "com.amazonaws" % "aws-lambda-java-core" % "1.2.1",
         "io.circe" %% "circe-generic" % circeVersion,
         "io.circe" %% "circe-parser" % circeVersion,
-        "com.squareup.okhttp3" % "okhttp" % "4.9.2"
+        "com.squareup.okhttp3" % "okhttp" % "4.9.2",
+        "org.scalatest" %% "scalatest" % "3.2.10" % Test
       )
   )
   .enablePlugins(RiffRaffArtifact)

--- a/src/main/scala/payment_failure_comms/BrazeConnector.scala
+++ b/src/main/scala/payment_failure_comms/BrazeConnector.scala
@@ -1,9 +1,11 @@
 package payment_failure_comms
 
-import io.circe.generic.auto._
-import io.circe.syntax._
+import com.amazonaws.services.lambda.runtime.LambdaLogger
+import io.circe.generic.auto.*
+import io.circe.syntax.*
 import okhttp3.{MediaType, OkHttpClient, Request, RequestBody, Response}
-import payment_failure_comms.models.{BrazeConfig, BrazeTrackRequest, BrazeRequestFailure, BrazeResponseFailure, Failure}
+import payment_failure_comms.models.{BrazeConfig, BrazeRequestFailure, BrazeResponseFailure, BrazeTrackRequest, Failure}
+
 import scala.util.Try
 
 object BrazeConnector {
@@ -11,36 +13,56 @@ object BrazeConnector {
   private val JSON: MediaType = MediaType.get("application/json; charset=utf-8")
   private val http = new OkHttpClient()
 
-  def sendCustomEvents(brazeConfig: BrazeConfig, payload: BrazeTrackRequest): Either[Failure, Unit] = {
+  def sendCustomEvents(brazeConfig: BrazeConfig, logger: LambdaLogger)(
+      payload: BrazeTrackRequest
+  ): Either[Failure, Unit] = {
     if (payload.events.isEmpty)
       Right(())
     else
-      handleRequestResult(
-        postRequest(
+      handleRequestResult(logger)(
+        responseToPostRequest(logger)(
           url = s"https://${brazeConfig.instanceUrl}/users/track",
           bearerToken = brazeConfig.bearerToken,
-          RequestBody.create(payload.asJson.toString, JSON)
+          body = payload.asJson.toString
         )
       )
   }
 
-  def postRequest(url: String, bearerToken: String, body: RequestBody): Either[Throwable, Response] = {
+  def responseToPostRequest(
+      logger: LambdaLogger
+  )(url: String, bearerToken: String, body: String): Either[Throwable, Response] = {
     val request: Request = new Request.Builder()
       .header("Authorization", s"Bearer ${bearerToken}")
       .url(url)
-      .post(body)
+      .post(RequestBody.create(body, JSON))
       .build()
+
+    Log.request(logger)(
+      service = Log.Service.Braze,
+      description = Some("Write custom events"),
+      url = request.url().toString,
+      method = request.method(),
+      body = Some(body)
+    )
 
     Try(
       http.newCall(request).execute()
     ).toEither
   }
 
-  def handleRequestResult(result: Either[Throwable, Response]): Either[Failure, Unit] = {
+  def handleRequestResult(logger: LambdaLogger)(result: Either[Throwable, Response]): Either[Failure, Unit] = {
     result
       .left.map(i => BrazeRequestFailure(s"Attempt to contact Braze failed with error: ${i.toString}"))
       .flatMap(response => {
         val body = response.body().string()
+
+        Log.response(logger)(
+          service = Log.Service.Braze,
+          url = response.request().url().toString,
+          method = response.request().method(),
+          responseCode = response.code(),
+          body = Some(body)
+        )
 
         if (response.isSuccessful) {
           Right(())

--- a/src/main/scala/payment_failure_comms/IdapiConnector.scala
+++ b/src/main/scala/payment_failure_comms/IdapiConnector.scala
@@ -1,47 +1,58 @@
 package payment_failure_comms
 
+import com.amazonaws.services.lambda.runtime.LambdaLogger
 import io.circe.Decoder
-import io.circe.generic.auto._
+import io.circe.generic.auto.*
 import io.circe.parser.decode
 import okhttp3.{MediaType, OkHttpClient, Request, Response}
-import payment_failure_comms.models.{
-  Failure,
-  IdapiConfig,
-  IdapiGetUserResponse,
-  IdapiRequestFailure,
-  IdapiResponseFailure
-}
+import payment_failure_comms.models.*
+
 import scala.util.Try
 
 object IdapiConnector {
 
   private val http = new OkHttpClient()
 
-  def getBrazeId(idapiConfig: IdapiConfig, IdentityId: String): Either[Failure, String] = {
-    handleRequestResult[IdapiGetUserResponse](
-      getRequest(
+  def getBrazeId(idapiConfig: IdapiConfig, logger: LambdaLogger)(IdentityId: String): Either[Failure, String] = {
+    handleRequestResult[IdapiGetUserResponse](logger)(
+      responseToGetRequest(logger)(
         url = s"https://${idapiConfig.instanceUrl}/user/${IdentityId}",
         bearerToken = idapiConfig.bearerToken
       )
-    ).map(response => response.user.privateFields.brazeUuid)
+    ).map(_.user.privateFields.brazeUuid)
   }
 
-  def getRequest(url: String, bearerToken: String): Either[Throwable, Response] = {
+  def responseToGetRequest(logger: LambdaLogger)(url: String, bearerToken: String): Either[Throwable, Response] = {
     val request: Request = new Request.Builder()
       .header("Authorization", s"Bearer ${bearerToken}")
       .url(url)
       .build()
+
+    Log.request(logger)(
+      service = Log.Service.Idapi,
+      description = Some("Read Braze UUID for an Identity ID"),
+      url = request.url().toString,
+      method = request.method()
+    )
 
     Try(
       http.newCall(request).execute()
     ).toEither
   }
 
-  def handleRequestResult[T: Decoder](result: Either[Throwable, Response]): Either[Failure, T] = {
+  def handleRequestResult[T: Decoder](logger: LambdaLogger)(result: Either[Throwable, Response]): Either[Failure, T] = {
     result
       .left.map(i => IdapiRequestFailure(s"Attempt to contact Braze failed with error: ${i.toString}"))
       .flatMap(response => {
         val body = response.body().string()
+
+        Log.response(logger)(
+          service = Log.Service.Idapi,
+          url = response.request().url().toString,
+          method = response.request().method(),
+          responseCode = response.code(),
+          body = Some(body)
+        )
 
         if (response.isSuccessful) {
           decode[T](body)

--- a/src/main/scala/payment_failure_comms/Log.scala
+++ b/src/main/scala/payment_failure_comms/Log.scala
@@ -1,0 +1,98 @@
+package payment_failure_comms
+
+import com.amazonaws.services.lambda.runtime.LambdaLogger
+import io.circe.Json
+import io.circe.generic.auto.*
+import io.circe.syntax.*
+import payment_failure_comms.models.Failure
+
+object Log {
+
+  private sealed trait LogLevel { def name: String }
+  private object LogLevel {
+    case object Info extends LogLevel {
+      val name = "INFO"
+    }
+    case object Error extends LogLevel {
+      val name = "ERROR"
+    }
+  }
+
+  sealed trait Service { def name: String }
+  object Service {
+    case object Salesforce extends Service {
+      val name = "Salesforce"
+    }
+    case object Braze extends Service {
+      val name = "Braze"
+    }
+    case object Idapi extends Service {
+      val name = "Idapi"
+    }
+  }
+
+  private case class InfoMessage(
+      logLevel: String = LogLevel.Info.name,
+      event: String,
+      description: Option[String] = None,
+      service: Option[String] = None,
+      url: Option[String] = None,
+      httpMethod: Option[String] = None,
+      query: Option[String] = None,
+      body: Option[String] = None,
+      responseCode: Option[Int] = None
+  )
+  private case class ErrorMessage(logLevel: String = LogLevel.Error.name, failure: String)
+
+  private def append(logger: LambdaLogger)(json: Json): Unit = logger.log(json.dropNullValues.noSpaces)
+  private def info(logger: LambdaLogger)(message: InfoMessage): Unit = append(logger)(message.asJson)
+  private def error(logger: LambdaLogger)(message: ErrorMessage): Unit = append(logger)(message.asJson)
+
+  def failure(logger: LambdaLogger)(failure: Failure): Unit =
+    error(logger)(ErrorMessage(failure = failure.details))
+
+  def request(logger: LambdaLogger)(
+      service: Service,
+      description: Option[String] = None,
+      url: String,
+      method: String,
+      query: Option[String] = None,
+      body: Option[String] = None
+  ): Unit =
+    info(logger)(
+      InfoMessage(
+        event = "Request",
+        service = Some(service.name),
+        description = description,
+        url = Some(url),
+        httpMethod = Some(method),
+        query = query,
+        body = body
+      )
+    )
+
+  def response(logger: LambdaLogger)(
+      service: Service,
+      description: Option[String] = None,
+      url: String,
+      method: String,
+      query: Option[String] = None,
+      responseCode: Int,
+      body: Option[String] = None
+  ): Unit =
+    info(logger)(
+      InfoMessage(
+        event = "Response",
+        service = Some(service.name),
+        description = description,
+        url = Some(url),
+        httpMethod = Some(method),
+        query = query,
+        responseCode = Some(responseCode),
+        body = body
+      )
+    )
+
+  def completion(logger: LambdaLogger)(): Unit =
+    info(logger)(InfoMessage(event = "Completion"))
+}

--- a/src/test/scala/payment_failure_comms/BrazeConnectorTests.scala
+++ b/src/test/scala/payment_failure_comms/BrazeConnectorTests.scala
@@ -10,19 +10,19 @@ class BrazeConnectorTests extends AnyFlatSpec with should.Matchers with EitherVa
 
   // handleRequestResult success cases
   "handleRequestResult" should "return Unit if the request was successul and the reply is 2xx" in {
-    BrazeConnector.handleRequestResult(successfulResponse) shouldBe Right(())
+    BrazeConnector.handleRequestResult(NoOpLogger())(successfulResponse) shouldBe Right(())
   }
 
   // handleRequestResult failure cases
   "handleRequestResult" should "return a BrazeRequestFailure if the request was unsuccessful" in {
-    val result = BrazeConnector.handleRequestResult(requestFailure)
+    val result = BrazeConnector.handleRequestResult(NoOpLogger())(requestFailure)
 
     result.isLeft shouldBe true
     result.left.value shouldBe a[BrazeRequestFailure]
   }
 
   "handleRequestResult" should "return a BrazeResponseFailure if the request was successful but an error code was received" in {
-    val result = BrazeConnector.handleRequestResult(failureResponse)
+    val result = BrazeConnector.handleRequestResult(NoOpLogger())(failureResponse)
 
     result.isLeft shouldBe true
     result.left.value shouldBe a[BrazeResponseFailure]

--- a/src/test/scala/payment_failure_comms/IdapiConnectorTests.scala
+++ b/src/test/scala/payment_failure_comms/IdapiConnectorTests.scala
@@ -18,26 +18,26 @@ class IdapiConnectorTests extends AnyFlatSpec with should.Matchers with EitherVa
 
   // handleRequestResult success cases
   "handleRequestResult" should "return the corrrectly formed case class if the request was successul and the reply is 2xx" in {
-    IdapiConnector.handleRequestResult[ResponseModel](successfulResponse) shouldBe Right(validBodyAsClass)
+    IdapiConnector.handleRequestResult[ResponseModel](NoOpLogger())(successfulResponse) shouldBe Right(validBodyAsClass)
   }
 
   // handleRequestResult failure cases
   "handleRequestResult" should "return an IdapiRequestFailure if the request was unsuccessful" in {
-    val result = IdapiConnector.handleRequestResult[ResponseModel](requestFailure)
+    val result = IdapiConnector.handleRequestResult[ResponseModel](NoOpLogger())(requestFailure)
 
     result.isLeft shouldBe true
     result.left.value shouldBe a[IdapiRequestFailure]
   }
 
   "handleRequestResult" should "return an IdapiResponseFailure if the request was successful but an error code was received" in {
-    val result = IdapiConnector.handleRequestResult[ResponseModel](failureResponse)
+    val result = IdapiConnector.handleRequestResult[ResponseModel](NoOpLogger())(failureResponse)
 
     result.isLeft shouldBe true
     result.left.value shouldBe a[IdapiResponseFailure]
   }
 
   "handleRequestResult" should "return an IdapiResponseFailure if the request was successful and the reply is 2xx but the body failed decoding" in {
-    val result = IdapiConnector.handleRequestResult[ResponseModel](unexpectedResponse)
+    val result = IdapiConnector.handleRequestResult[ResponseModel](NoOpLogger())(unexpectedResponse)
 
     result.isLeft shouldBe true
     result.left.value shouldBe a[IdapiResponseFailure]

--- a/src/test/scala/payment_failure_comms/NoOpLogger.scala
+++ b/src/test/scala/payment_failure_comms/NoOpLogger.scala
@@ -1,0 +1,10 @@
+package payment_failure_comms
+
+import com.amazonaws.services.lambda.runtime.LambdaLogger
+
+object NoOpLogger {
+  def apply() = new LambdaLogger {
+    def log(message: String): Unit = ()
+    def log(message: Array[Byte]): Unit = ()
+  }
+}

--- a/src/test/scala/payment_failure_comms/SalesforceConnectorTests.scala
+++ b/src/test/scala/payment_failure_comms/SalesforceConnectorTests.scala
@@ -1,6 +1,7 @@
 package payment_failure_comms
 
-import io.circe.generic.auto._
+import com.amazonaws.services.lambda.runtime.LambdaLogger
+import io.circe.generic.auto.*
 import org.scalatest.EitherValues
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should
@@ -18,26 +19,28 @@ class SalesforceConnectorTests extends AnyFlatSpec with should.Matchers with Eit
 
   // handleRequestResult success cases
   "handleRequestResult" should "return the correctly formed case class if the request was successul and the reply is 2xx" in {
-    SalesforceConnector.handleRequestResult[ResponseModel](successfulResponse) shouldBe Right(validBodyAsClass)
+    SalesforceConnector.handleRequestResult[ResponseModel](NoOpLogger())(successfulResponse) shouldBe Right(
+      validBodyAsClass
+    )
   }
 
   // handleRequestResult failure cases
   "handleRequestResult" should "return a SalesforceRequestFailure if the request was unsuccessful" in {
-    val result = SalesforceConnector.handleRequestResult[ResponseModel](requestFailure)
+    val result = SalesforceConnector.handleRequestResult[ResponseModel](NoOpLogger())(requestFailure)
 
     result.isLeft shouldBe true
     result.left.value shouldBe a[SalesforceRequestFailure]
   }
 
   "handleRequestResult" should "return a SalesforceResponseFailure if the request was successful but an error code was received" in {
-    val result = SalesforceConnector.handleRequestResult[ResponseModel](failureResponse)
+    val result = SalesforceConnector.handleRequestResult[ResponseModel](NoOpLogger())(failureResponse)
 
     result.isLeft shouldBe true
     result.left.value shouldBe a[SalesforceResponseFailure]
   }
 
   "handleRequestResult" should "return a SalesforceResponseFailure if the request was successful and the reply is 2xx but the body failed decoding" in {
-    val result = SalesforceConnector.handleRequestResult[ResponseModel](unexpectedResponse)
+    val result = SalesforceConnector.handleRequestResult[ResponseModel](NoOpLogger())(unexpectedResponse)
 
     result.isLeft shouldBe true
     result.left.value shouldBe a[SalesforceResponseFailure]


### PR DESCRIPTION
This change adds structured logging of the most significant events.

The events logged are:
* failures
* requests out to services
* responses
* successful completion

Log entries are structured as Json so that they can be easily analysed in Cloudwatch [Logs Insights](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/CWL_QuerySyntax-examples.html).
This allows us to filter for Salesforce responses, for example:
```
fields @timestamp, @message
| filter service = 'Salesforce' and event = 'Response'
| sort @timestamp desc
| limit 20
```
