### PR TITLE
Migrate CI from Teamcity to Github Action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    # Required by actions-assume-aws-role
     permissions:
       id-token: write
       contents: read
@@ -23,6 +24,7 @@ jobs:
       - name: Restore and save dependency cache
         uses: coursier/cache-action@v6
 
+        # Required by sbt riffRaffUpload
       - name: Assume AWS role
         uses: guardian/actions-assume-aws-role@v1
         with:


### PR DESCRIPTION
This change adds a new CI workflow, courtesy of the [assume-AWS-role action](https://github.com/guardian/actions-assume-aws-role) and the [instructions given in the sbt-riffraff-artifact repo](https://github.com/guardian/sbt-riffraff-artifact#migrating-riff-raff-project-to-github-actions-from-teamcity).

The benefits of moving from Teamcity to a Github workflow are:
1. The deployment steps are reduced to Github and Riffraff so easier to understand and troubleshoot.
1. The deployment configuration is all in the codebase alongside the code.
1. Any changes to the deployment configuration have an audit trail.
1. It's much quicker and easier to set up the configuration.

I still need to delete the build from Teamcity, which is currently paused.
