### PR TITLE
Add compiler options

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,11 @@
 ThisBuild / scalaVersion := "3.1.0"
 
+ThisBuild / scalacOptions ++= Seq(
+  "-explain",
+  "-deprecation",
+  "-Xfatal-warnings"
+)
+
 val circeVersion = "0.14.1"
 
 lazy val root = (project in file("."))


### PR DESCRIPTION
The compiler options are described [here](https://docs.scala-lang.org/overviews/compiler-options/index.html) and [here](https://docs.scala-lang.org/scala3/guides/migration/options-new.html).

`explain` = Explain errors in more detail.

`deprecation` = Emit warning and location for usages of deprecated APIs.

`fatal-warnings` = Fail the compilation if there are any warnings.
This is to make sure CI and other workflows fail on warnings so that they're not overlooked.
 