### PR TITLE
Downgrade to Scala 2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,6 @@
-ThisBuild / scalaVersion := "3.1.0"
+ThisBuild / scalaVersion := "2.13.6"
 
 ThisBuild / scalacOptions ++= Seq(
-  "-explain",
   "-deprecation",
   "-Xfatal-warnings"
 )

--- a/src/main/scala/payment_failure_comms/BrazeConnector.scala
+++ b/src/main/scala/payment_failure_comms/BrazeConnector.scala
@@ -1,8 +1,8 @@
 package payment_failure_comms
 
 import com.amazonaws.services.lambda.runtime.LambdaLogger
-import io.circe.generic.auto.*
-import io.circe.syntax.*
+import io.circe.generic.auto._
+import io.circe.syntax._
 import okhttp3.{MediaType, OkHttpClient, Request, RequestBody, Response}
 import payment_failure_comms.models.{BrazeConfig, BrazeRequestFailure, BrazeResponseFailure, BrazeTrackRequest, Failure}
 

--- a/src/main/scala/payment_failure_comms/IdapiConnector.scala
+++ b/src/main/scala/payment_failure_comms/IdapiConnector.scala
@@ -2,10 +2,10 @@ package payment_failure_comms
 
 import com.amazonaws.services.lambda.runtime.LambdaLogger
 import io.circe.Decoder
-import io.circe.generic.auto.*
+import io.circe.generic.auto._
 import io.circe.parser.decode
 import okhttp3.{MediaType, OkHttpClient, Request, Response}
-import payment_failure_comms.models.*
+import payment_failure_comms.models._
 
 import scala.util.Try
 

--- a/src/main/scala/payment_failure_comms/Log.scala
+++ b/src/main/scala/payment_failure_comms/Log.scala
@@ -2,8 +2,8 @@ package payment_failure_comms
 
 import com.amazonaws.services.lambda.runtime.LambdaLogger
 import io.circe.Json
-import io.circe.generic.auto.*
-import io.circe.syntax.*
+import io.circe.generic.auto._
+import io.circe.syntax._
 import payment_failure_comms.models.Failure
 
 object Log {

--- a/src/main/scala/payment_failure_comms/SalesforceConnector.scala
+++ b/src/main/scala/payment_failure_comms/SalesforceConnector.scala
@@ -2,15 +2,15 @@ package payment_failure_comms
 
 import com.amazonaws.services.lambda.runtime.LambdaLogger
 import io.circe.Decoder
-import io.circe.generic.auto.*
+import io.circe.generic.auto._
 import io.circe.parser.decode
-import io.circe.syntax.*
-import okhttp3.*
-import payment_failure_comms.models.*
+import io.circe.syntax._
+import okhttp3._
+import payment_failure_comms.models._
 
 import scala.language.implicitConversions
 import scala.util.Try
-import scala.util.chaining.*
+import scala.util.chaining._
 
 class SalesforceConnector(authDetails: SalesforceAuth, apiVersion: String, logger: LambdaLogger) {
   def getRecordsToProcess(): Either[Failure, Seq[PaymentFailureRecord]] =

--- a/src/test/scala/payment_failure_comms/SalesforceConnectorTests.scala
+++ b/src/test/scala/payment_failure_comms/SalesforceConnectorTests.scala
@@ -1,7 +1,7 @@
 package payment_failure_comms
 
 import com.amazonaws.services.lambda.runtime.LambdaLogger
-import io.circe.generic.auto.*
+import io.circe.generic.auto._
 import org.scalatest.EitherValues
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should


### PR DESCRIPTION
Because Intellij doesn't work well with Scala 3 at the moment.  It becomes like working with a basic text editor.  Even the EAP doesn't seem to work very nicely.

