### PR TITLE
Read Braze events before writing them

### DIFF
--- a/src/main/scala/payment_failure_comms/BrazeConnector.scala
+++ b/src/main/scala/payment_failure_comms/BrazeConnector.scala
@@ -2,9 +2,10 @@ package payment_failure_comms
 
 import com.amazonaws.services.lambda.runtime.LambdaLogger
 import io.circe.generic.auto._
+import io.circe.parser.decode
 import io.circe.syntax._
-import okhttp3.{MediaType, OkHttpClient, Request, RequestBody, Response}
-import payment_failure_comms.models.{BrazeConfig, BrazeRequestFailure, BrazeResponseFailure, BrazeTrackRequest, Failure}
+import okhttp3._
+import payment_failure_comms.models._
 
 import scala.util.Try
 
@@ -12,6 +13,41 @@ object BrazeConnector {
 
   private val JSON: MediaType = MediaType.get("application/json; charset=utf-8")
   private val http = new OkHttpClient()
+
+  def fetchCustomEvents(brazeConfig: BrazeConfig, logger: LambdaLogger)(
+      payload: BrazeUserRequest
+  ): Either[Failure, BrazeUserResponse] = {
+    if (payload.external_ids.isEmpty)
+      Right(BrazeUserResponse(Nil))
+    else
+      responseToPostRequest(logger)(
+        url = s"https://${brazeConfig.instanceUrl}/users/export/ids",
+        bearerToken = brazeConfig.bearerToken,
+        body = payload.asJson.toString
+      )
+        .left.map(ex => BrazeRequestFailure(s"Attempt to contact Braze failed with error: ${ex.toString}"))
+        .flatMap(response => {
+
+          val body = response.body().string()
+
+          Log.response(logger)(
+            service = Log.Service.Braze,
+            url = response.request().url().toString,
+            method = response.request().method(),
+            responseCode = response.code(),
+            body = Some(body)
+          )
+
+          if (response.isSuccessful) {
+            decode[BrazeUserResponse](body)
+              .left.map(decodeError =>
+                BrazeResponseFailure(s"Failed to decode successful response:$decodeError. Body to decode $body")
+              )
+          } else {
+            Left(BrazeResponseFailure(s"The request to Braze was unsuccessful: ${response.code} - $body"))
+          }
+        })
+  }
 
   def sendCustomEvents(brazeConfig: BrazeConfig, logger: LambdaLogger)(
       payload: BrazeTrackRequest
@@ -32,14 +68,13 @@ object BrazeConnector {
       logger: LambdaLogger
   )(url: String, bearerToken: String, body: String): Either[Throwable, Response] = {
     val request: Request = new Request.Builder()
-      .header("Authorization", s"Bearer ${bearerToken}")
+      .header("Authorization", s"Bearer $bearerToken")
       .url(url)
       .post(RequestBody.create(body, JSON))
       .build()
 
     Log.request(logger)(
       service = Log.Service.Braze,
-      description = Some("Write custom events"),
       url = request.url().toString,
       method = request.method(),
       body = Some(body)
@@ -67,7 +102,7 @@ object BrazeConnector {
         if (response.isSuccessful) {
           Right(())
         } else {
-          Left(BrazeResponseFailure(s"The request to Braze was unsuccessful: ${response.code} - ${body}"))
+          Left(BrazeResponseFailure(s"The request to Braze was unsuccessful: ${response.code} - $body"))
         }
       })
   }

--- a/src/main/scala/payment_failure_comms/models/BrazeUserData.scala
+++ b/src/main/scala/payment_failure_comms/models/BrazeUserData.scala
@@ -1,0 +1,23 @@
+package payment_failure_comms.models
+
+import java.time.ZonedDateTime
+
+/*
+ * Braze response model for /users/export/id endpoint, serialized as Json.
+ */
+case class BrazeUserResponse(users: Seq[User])
+case class User(external_id: String, custom_events: Seq[UserCustomEvent])
+case class UserCustomEvent(name: String, first: ZonedDateTime, last: ZonedDateTime, count: Int)
+
+/*
+ * Braze request model for /users/export/id endpoint, serialized as Json.
+ */
+case class BrazeUserRequest(external_ids: Seq[String], fields_to_export: Seq[String])
+
+object BrazeUserRequest {
+  def fromPaymentFailureRecords(records: Seq[PaymentFailureRecordWithBrazeId]): BrazeUserRequest =
+    BrazeUserRequest(
+      external_ids = records.map(_.brazeId),
+      fields_to_export = Seq("external_id", "custom_events")
+    )
+}

--- a/src/main/scala/payment_failure_comms/models/brazeTrackEvents.scala
+++ b/src/main/scala/payment_failure_comms/models/brazeTrackEvents.scala
@@ -1,7 +1,6 @@
 package payment_failure_comms.models
 
 import java.time.ZonedDateTime
-import java.time.format.DateTimeFormatter
 
 case class BrazeTrackRequest(events: Seq[CustomEvent])
 
@@ -12,7 +11,6 @@ case class EventProperties(product: String, currency: String, amount: Double)
 
 object BrazeTrackRequest {
 
-  val dateTimeFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss:SSSZ")
   val eventNameMapping = Map(
     "In Progress" -> "payment_failure",
     "Recovered" -> "payment_recovery",

--- a/src/test/scala/payment_failure_comms/models/BrazeTrackRequestTest.scala
+++ b/src/test/scala/payment_failure_comms/models/BrazeTrackRequestTest.scala
@@ -2,10 +2,8 @@ package payment_failure_comms.models
 
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should
-import payment_failure_comms.{BrazeConnector, NoOpLogger}
-import payment_failure_comms.testData.ConnectorTestData.successfulResponse
 
-import java.time.{LocalDate, OffsetDateTime, ZoneOffset}
+import java.time._
 
 class BrazeTrackRequestTest extends AnyFlatSpec with should.Matchers {
 
@@ -35,7 +33,8 @@ class BrazeTrackRequestTest extends AnyFlatSpec with should.Matchers {
   "Apply" should "succeed if no records" in {
     BrazeTrackRequest(
       records = Nil,
-      zuoraAppId = "z1"
+      zuoraAppId = "z1",
+      eventsAlreadyWritten = BrazeUserResponse(Nil)
     ) shouldBe Right(BrazeTrackRequest(Nil))
   }
 
@@ -46,7 +45,8 @@ class BrazeTrackRequestTest extends AnyFlatSpec with should.Matchers {
         mkPaymentFailureRecord(2, "Failed"),
         mkPaymentFailureRecord(3, "Auto-Cancel Failure")
       ),
-      zuoraAppId = "z1"
+      zuoraAppId = "z1",
+      eventsAlreadyWritten = BrazeUserResponse(Nil)
     ) shouldBe Right(
       BrazeTrackRequest(
         Seq(
@@ -83,7 +83,178 @@ class BrazeTrackRequestTest extends AnyFlatSpec with should.Matchers {
         mkPaymentFailureRecord(2, "Unknown status"),
         mkPaymentFailureRecord(3, "Auto-Cancel Failure")
       ),
-      zuoraAppId = "z1"
+      zuoraAppId = "z1",
+      eventsAlreadyWritten = BrazeUserResponse(Nil)
     ) shouldBe Left(SalesforceResponseFailure("Unexpected status value 'Unknown status' in PF record 2"))
+  }
+
+  "diff" should "give an empty list if no events" in {
+    val events = Nil
+    val eventsAlreadyWritten = BrazeUserResponse(Nil)
+    BrazeTrackRequest.diff(events, eventsAlreadyWritten) shouldBe Nil
+  }
+
+  it should "give complete list of events if none already written" in {
+    val events = Seq(
+      CustomEvent(
+        external_id = "ei1",
+        app_id = "z1",
+        name = "payment_failure",
+        time = "2021-10-26T11:15:27Z",
+        properties = EventProperties(product = "p1", currency = "GBP", amount = 1.2)
+      )
+    )
+    val eventsAlreadyWritten = BrazeUserResponse(users =
+      Seq(
+        User(
+          external_id = "ei2",
+          custom_events = Seq(
+            UserCustomEvent(
+              name = "payment_recovery",
+              first = ZonedDateTime.of(2019, 10, 10, 4, 6, 12, 0, ZoneId.of("UTC")),
+              last = ZonedDateTime.of(2020, 2, 3, 4, 5, 6, 0, ZoneId.of("UTC")),
+              count = 3
+            )
+          )
+        )
+      )
+    )
+    BrazeTrackRequest.diff(events, eventsAlreadyWritten) shouldBe Seq(
+      CustomEvent(
+        external_id = "ei1",
+        app_id = "z1",
+        name = "payment_failure",
+        time = "2021-10-26T11:15:27Z",
+        properties = EventProperties(product = "p1", currency = "GBP", amount = 1.2)
+      )
+    )
+  }
+
+  it should "miss out events that match those already written" in {
+    val events = Seq(
+      CustomEvent(
+        external_id = "ei1",
+        app_id = "z1",
+        name = "payment_failure",
+        time = "2021-10-26T11:15:27Z",
+        properties = EventProperties(product = "p1", currency = "GBP", amount = 1.2)
+      )
+    )
+    val eventsAlreadyWritten = BrazeUserResponse(users =
+      Seq(
+        User(
+          external_id = "ei1",
+          custom_events = Seq(
+            UserCustomEvent(
+              name = "payment_failure",
+              first = ZonedDateTime.of(2019, 10, 10, 4, 6, 12, 0, ZoneId.of("UTC")),
+              last = ZonedDateTime.of(2021, 10, 26, 11, 15, 27, 0, ZoneId.of("UTC")),
+              count = 3
+            )
+          )
+        )
+      )
+    )
+    BrazeTrackRequest.diff(events, eventsAlreadyWritten) shouldBe Nil
+  }
+
+  it should "not miss out events where name doesn't match" in {
+    val events = Seq(
+      CustomEvent(
+        external_id = "ei1",
+        app_id = "z1",
+        name = "payment_failure",
+        time = "2021-10-26T11:15:27Z",
+        properties = EventProperties(product = "p1", currency = "GBP", amount = 1.2)
+      )
+    )
+    val eventsAlreadyWritten = BrazeUserResponse(users =
+      Seq(
+        User(
+          external_id = "ei1",
+          custom_events = Seq(
+            UserCustomEvent(
+              name = "payment_recovery",
+              first = ZonedDateTime.of(2019, 10, 10, 4, 6, 12, 0, ZoneId.of("UTC")),
+              last = ZonedDateTime.of(2021, 10, 26, 11, 15, 27, 0, ZoneId.of("UTC")),
+              count = 3
+            )
+          )
+        )
+      )
+    )
+    BrazeTrackRequest.diff(events, eventsAlreadyWritten) shouldBe Seq(
+      CustomEvent(
+        external_id = "ei1",
+        app_id = "z1",
+        name = "payment_failure",
+        time = "2021-10-26T11:15:27Z",
+        properties = EventProperties(product = "p1", currency = "GBP", amount = 1.2)
+      )
+    )
+  }
+
+  it should "not miss out events where last time of same event was before the time of the event" in {
+    val events = Seq(
+      CustomEvent(
+        external_id = "ei1",
+        app_id = "z1",
+        name = "payment_failure",
+        time = "2021-10-26T11:15:27Z",
+        properties = EventProperties(product = "p1", currency = "GBP", amount = 1.2)
+      )
+    )
+    val eventsAlreadyWritten = BrazeUserResponse(users =
+      Seq(
+        User(
+          external_id = "ei1",
+          custom_events = Seq(
+            UserCustomEvent(
+              name = "payment_failure",
+              first = ZonedDateTime.of(2019, 10, 10, 4, 6, 12, 0, ZoneId.of("UTC")),
+              last = ZonedDateTime.of(2020, 10, 26, 11, 15, 27, 0, ZoneId.of("UTC")),
+              count = 3
+            )
+          )
+        )
+      )
+    )
+    BrazeTrackRequest.diff(events, eventsAlreadyWritten) shouldBe Seq(
+      CustomEvent(
+        external_id = "ei1",
+        app_id = "z1",
+        name = "payment_failure",
+        time = "2021-10-26T11:15:27Z",
+        properties = EventProperties(product = "p1", currency = "GBP", amount = 1.2)
+      )
+    )
+  }
+
+  it should "miss out events where last time of same event was after the time of the event" in {
+    val events = Seq(
+      CustomEvent(
+        external_id = "ei1",
+        app_id = "z1",
+        name = "payment_failure",
+        time = "2021-10-26T11:15:27Z",
+        properties = EventProperties(product = "p1", currency = "GBP", amount = 1.2)
+      )
+    )
+    val eventsAlreadyWritten = BrazeUserResponse(users =
+      Seq(
+        User(
+          external_id = "ei1",
+          custom_events = Seq(
+            UserCustomEvent(
+              name = "payment_failure",
+              first = ZonedDateTime.of(2019, 10, 10, 4, 6, 12, 0, ZoneId.of("UTC")),
+              last = ZonedDateTime.of(2021, 10, 27, 11, 15, 27, 0, ZoneId.of("UTC")),
+              count = 3
+            )
+          )
+        )
+      )
+    )
+    BrazeTrackRequest.diff(events, eventsAlreadyWritten) shouldBe Nil
   }
 }


### PR DESCRIPTION
This change ensures that we don't write duplicate custom events to Braze.
For each relevant payment-failure record in Salesforce, we check for corresponding events in Braze before writing them.

The response from Braze doesn't tell us the properties of events.  It just tells us event names and the first and last dates that they occurred.  From this, we can say that an event with the same name as an existing event on the same account shouldn't be written to the account if the existing event has the same or later date than the event we're considering writing.

The scenario in which we could get duplicate events is:
1. Read payment-failure records from Salesforce is successful
2. Write events to Braze is successful
3. Write results back to Salesforce fails

In this scenario, on the next attempt we would read the same record from Salesforce and write it to Braze again, which  would give duplicate events.
