### PR TITLE
Use new status values

### DIFF
--- a/src/main/scala/payment_failure_comms/SalesforceConnector.scala
+++ b/src/main/scala/payment_failure_comms/SalesforceConnector.scala
@@ -51,7 +51,6 @@ object SalesforceConnector {
       """
       |SELECT 
       |  Id,
-      |  Status__c,
       |  Contact__r.IdentityID__c,
       |  SF_Subscription__r.Product_Name__c,
       |  SF_Subscription__r.Cancellation_Request_Date__c,

--- a/src/main/scala/payment_failure_comms/SalesforceConnector.scala
+++ b/src/main/scala/payment_failure_comms/SalesforceConnector.scala
@@ -12,7 +12,6 @@ import java.time.OffsetDateTime
 import java.time.format.DateTimeFormatter
 import scala.language.implicitConversions
 import scala.util.Try
-import scala.util.chaining._
 
 class SalesforceConnector(authDetails: SalesforceAuth, apiVersion: String, logger: LambdaLogger) {
   def getRecordsToProcess(): Either[Failure, Seq[PaymentFailureRecord]] =
@@ -50,21 +49,28 @@ object SalesforceConnector {
     // Query limited to 200 records to avoid Salesforce's governor limits on number of requests per response
     val query =
       """
-      |SELECT Id,
-      |   Status__c,
-      |   Contact__r.IdentityID__c,
-      |   SF_Subscription__r.Product_Name__c,
-      |   SF_Subscription__r.Cancellation_Request_Date__c,
-      |   PF_Comms_Status__c, 
-      |   PF_Comms_Last_Stage_Processed__c, 
-      |   PF_Comms_Number_of_Attempts__c,
-      |   Currency__c,
-      |   Invoice_Total_Amount__c,
-      |   Initial_Payment_Created_Date__c,
-      |   Last_Attempt_Date__c,
-      |   Cut_Off_Date__c
+      |SELECT 
+      |  Id,
+      |  Status__c,
+      |  Contact__r.IdentityID__c,
+      |  SF_Subscription__r.Product_Name__c,
+      |  SF_Subscription__r.Cancellation_Request_Date__c,
+      |  PF_Comms_Status__c, 
+      |  PF_Comms_Last_Stage_Processed__c, 
+      |  PF_Comms_Number_of_Attempts__c,
+      |  Currency__c,
+      |  Invoice_Total_Amount__c,
+      |  Initial_Payment_Created_Date__c,
+      |  Last_Attempt_Date__c,
+      |  Cut_Off_Date__c
       |FROM Payment_Failure__c
-      |WHERE PF_Comms_Status__c In ('Ready to process entry', 'Ready to process exit')
+      |WHERE PF_Comms_Status__c
+      |IN (
+      |  'Ready to send entry event',
+      |  'Ready to send recovery event',
+      |  'Ready to send voluntary cancel event',
+      |  'Ready to send auto cancel event'
+      |)
       |LIMIT 200""".stripMargin
 
     handleRequestResult[SFPaymentFailureRecordWrapper](logger)(
@@ -139,10 +145,10 @@ object SalesforceConnector {
       .parse(url)
       .newBuilder()
       .addQueryParameter("q", query)
-      .build();
+      .build()
 
     val request: Request = new Request.Builder()
-      .header("Authorization", s"Bearer ${bearerToken}")
+      .header("Authorization", s"Bearer $bearerToken")
       .url(urlWithParam)
       .get()
       .build()
@@ -164,7 +170,7 @@ object SalesforceConnector {
       logger: LambdaLogger
   )(url: String, bearerToken: String, body: String): Either[Throwable, Response] = {
     val request: Request = new Request.Builder()
-      .header("Authorization", s"Bearer ${bearerToken}")
+      .header("Authorization", s"Bearer $bearerToken")
       .url(url)
       .patch(RequestBody.create(body, JSON))
       .build()
@@ -199,10 +205,10 @@ object SalesforceConnector {
         if (response.isSuccessful) {
           decode[T](body)
             .left.map(decodeError =>
-              SalesforceResponseFailure(s"Failed to decode successful response:$decodeError. Body to decode ${body}")
+              SalesforceResponseFailure(s"Failed to decode successful response:$decodeError. Body to decode $body")
             )
         } else {
-          Left(SalesforceResponseFailure(s"The request to Salesforce was unsuccessful: ${response.code} - ${body}"))
+          Left(SalesforceResponseFailure(s"The request to Salesforce was unsuccessful: ${response.code} - $body"))
         }
       })
   }

--- a/src/main/scala/payment_failure_comms/models/PaymentFailureRecord.scala
+++ b/src/main/scala/payment_failure_comms/models/PaymentFailureRecord.scala
@@ -1,15 +1,11 @@
 package payment_failure_comms.models
 
-import java.time.ZoneOffset.UTC
-import java.time.format.DateTimeFormatter
-import java.time.format.DateTimeFormatter.ISO_OFFSET_DATE_TIME
-import java.time.{LocalDate, OffsetDateTime, ZoneOffset}
+import java.time.{LocalDate, OffsetDateTime}
 
 case class PaymentFailureRecord(
     Id: String,
     Contact__r: SFContact,
     SF_Subscription__r: SFSubscription,
-    Status__c: String,
     PF_Comms_Status__c: String,
     PF_Comms_Last_Stage_Processed__c: Option[String] = None,
     PF_Comms_Number_of_Attempts__c: Option[Int] = Some(0),

--- a/src/main/scala/payment_failure_comms/models/PaymentFailureRecordUpdate.scala
+++ b/src/main/scala/payment_failure_comms/models/PaymentFailureRecordUpdate.scala
@@ -16,10 +16,10 @@ case class PaymentFailureRecordUpdateRequest(records: Seq[PaymentFailureRecordUp
 object PaymentFailureRecordUpdate {
 
   val eventStageMapping = Map(
-    "In Progress" -> "Entry",
-    "Recovered" -> "Exit",
-    "Auto-Cancel Failure" -> "Exit",
-    "Already Cancelled" -> "Exit"
+    "Ready to send entry event" -> "Entry",
+    "Ready to send recovery event" -> "Exit",
+    "Ready to send voluntary cancel event" -> "Exit",
+    "Ready to send auto cancel event" -> "Exit"
   )
 
   def apply(brazeResult: Either[Failure, Unit])(record: PaymentFailureRecord): PaymentFailureRecordUpdate =
@@ -28,15 +28,15 @@ object PaymentFailureRecordUpdate {
       case Left(_)  => failedUpdate(record)
     }
 
-  def successfulUpdate(record: PaymentFailureRecord) = {
+  def successfulUpdate(record: PaymentFailureRecord): PaymentFailureRecordUpdate = {
     PaymentFailureRecordUpdate(
       Id = record.Id,
-      PF_Comms_Last_Stage_Processed__c = eventStageMapping.get(record.Status__c),
+      PF_Comms_Last_Stage_Processed__c = eventStageMapping.get(record.PF_Comms_Status__c),
       PF_Comms_Number_of_Attempts__c = 0
     )
   }
 
-  def failedUpdate(record: PaymentFailureRecord) = {
+  def failedUpdate(record: PaymentFailureRecord): PaymentFailureRecordUpdate = {
     PaymentFailureRecordUpdate(
       Id = record.Id,
       PF_Comms_Last_Stage_Processed__c = record.PF_Comms_Last_Stage_Processed__c,

--- a/src/main/scala/payment_failure_comms/models/brazeTrackEvents.scala
+++ b/src/main/scala/payment_failure_comms/models/brazeTrackEvents.scala
@@ -12,10 +12,10 @@ case class EventProperties(product: String, currency: String, amount: Double)
 object BrazeTrackRequest {
 
   private val eventNameMapping = Map(
-    "Ready to send entry event" -> "payment_failure",
-    "Ready to send recovery event" -> "payment_recovery",
-    "Ready to send voluntary cancel event" -> "cancel_voluntary",
-    "Ready to send auto cancel event" -> "cancel_auto"
+    "Ready to send entry event" -> "pf_entry",
+    "Ready to send recovery event" -> "pf_recovery",
+    "Ready to send voluntary cancel event" -> "pf_cancel_voluntary",
+    "Ready to send auto cancel event" -> "pf_cancel_auto"
   )
 
   private[models] def diff(events: Seq[CustomEvent], eventsAlreadyWritten: BrazeUserResponse): Seq[CustomEvent] =

--- a/src/test/scala/payment_failure_comms/models/BrazeTrackRequestTest.scala
+++ b/src/test/scala/payment_failure_comms/models/BrazeTrackRequestTest.scala
@@ -52,21 +52,21 @@ class BrazeTrackRequestTest extends AnyFlatSpec with should.Matchers {
           CustomEvent(
             external_id = "b1",
             app_id = "z1",
-            name = "payment_recovery",
+            name = "pf_recovery",
             time = "2021-10-26T00:00:00Z",
             properties = EventProperties(product = "prod1", currency = "GBP", amount = 1.2)
           ),
           CustomEvent(
             external_id = "b2",
             app_id = "z1",
-            name = "cancel_voluntary",
+            name = "pf_cancel_voluntary",
             time = "2021-10-25T10:15:01Z",
             properties = EventProperties(product = "prod1", currency = "GBP", amount = 1.2)
           ),
           CustomEvent(
             external_id = "b3",
             app_id = "z1",
-            name = "cancel_auto",
+            name = "pf_cancel_auto",
             time = "2021-10-27T00:00:00Z",
             properties = EventProperties(product = "prod1", currency = "GBP", amount = 1.2)
           )


### PR DESCRIPTION
As a result of guardian/salesforce#499, we no longer need to use the `Status__c` field, as `PF_Comms_Status__c` has all the data needed to decide what to send to Braze.
This change replaces all the uses of `Status__c` and uses the new list of possible values for `PF_Comms_Status__c`.

