### PR TITLE
Check formatting during CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,5 +39,5 @@ jobs:
       - name: Run SBT tasks
         run: >
           sbt
-          clean
+          scalafmtCheckAll
           riffRaffUpload

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,5 +39,7 @@ jobs:
       - name: Run SBT tasks
         run: >
           sbt
+          clean
           scalafmtCheckAll
+          scalafmtSbtCheck
           riffRaffUpload

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,3 @@
 addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.17")
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "1.1.0")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.3")


### PR DESCRIPTION
This adds a check during CI that all production, test and SBT config files are formatted according to the scalafmt [config rules](https://github.com/guardian/payment-failure-comms/blob/main/.scalafmt.conf).
See https://scalameta.org/scalafmt/docs/installation.html#task-keys
