### PR TITLE
Set off alarm on lambda failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,12 @@ Check out the ADR docs [here](https://drive.google.com/drive/folders/1UZ7_HDLACK
 
 This repo is deployed by a [Github CI workflow](https://github.com/guardian/payment-failure-comms/blob/main/.github/workflows/ci.yml) and Riffraff.  
 There is a [paused build](https://teamcity.gutools.co.uk/buildConfiguration/memsub_MembershipAdmin_Build?branch=%3Cdefault%3E&buildTypeTab=overview&mode=builds) in Teamcity, which is due to be deleted on 22 Nov 2021 if there are no problems before then.
+
+## Alarms
+
+An alarm is set off when the lambda fails.  
+To resolve the failure:
+
+1. Look for errors in the Cloudwatch logs attached to the lambda.
+
+This will be updated as we accumulate reasons for the alarm going off.

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -123,12 +123,10 @@ Resources:
 
   FailureAlarm:
     Type: AWS::CloudWatch::Alarm
-#    TODO reinstate
-#    Condition: IsProd
+    Condition: IsProd
     DependsOn: PaymentFailureCommsLambda
     Properties:
-#      AlarmName: "URGENT 9-5 - PROD: Failed to send payment-failure events to Braze"
-      AlarmName: "Testing PF alarm"
+      AlarmName: "URGENT 9-5 - PROD: Failed to send payment-failure events to Braze"
       AlarmDescription: >
         IMPACT: If this goes unaddressed, at least one payment-failure event won't be communicated to the customer.
         For resolution steps, see https://github.com/guardian/payment-failure-comms/blob/main/README.md#alarms.

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -127,7 +127,8 @@ Resources:
 #    Condition: IsProd
     DependsOn: PaymentFailureCommsLambda
     Properties:
-      AlarmName: "URGENT 9-5 - PROD: Failed to send payment-failure events to Braze"
+#      AlarmName: "URGENT 9-5 - PROD: Failed to send payment-failure events to Braze"
+      AlarmName: "Testing PF alarm"
       AlarmDescription: >
         IMPACT: If this goes unaddressed, at least one payment-failure event won't be communicated to the customer.
         For resolution steps, see https://github.com/guardian/payment-failure-comms/blob/main/README.md#alarms.

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -123,7 +123,8 @@ Resources:
 
   FailureAlarm:
     Type: AWS::CloudWatch::Alarm
-    Condition: IsProd
+#    TODO reinstate
+#    Condition: IsProd
     DependsOn: PaymentFailureCommsLambda
     Properties:
       AlarmName: "URGENT 9-5 - PROD: Failed to send payment-failure events to Braze"

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -1,4 +1,5 @@
 Transform: AWS::Serverless-2016-10-31
+Description: Source code in https://github.com/guardian/payment-failure-comms
 
 Parameters:
   Stage:
@@ -119,3 +120,26 @@ Resources:
             Schedule: !FindInMap [ StageMap, !Ref Stage, Schedule ]
             Description: Send payment failure communications
             Enabled: False
+
+  FailureAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: IsProd
+    DependsOn: PaymentFailureCommsLambda
+    Properties:
+      AlarmName: "URGENT 9-5 - PROD: Failed to send payment-failure events to Braze"
+      AlarmDescription: >
+        IMPACT: If this goes unaddressed, at least one payment-failure event won't be communicated to the customer.
+        For resolution steps, see https://github.com/guardian/payment-failure-comms/blob/main/README.md#alarms.
+      AlarmActions:
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:retention-dev
+      MetricName: Errors
+      Namespace: AWS/Lambda
+      Dimensions:
+        - Name: FunctionName
+          Value: !Ref PaymentFailureCommsLambda
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      Threshold: 1
+      Statistic: Sum
+      Period: 60
+      EvaluationPeriods: 1
+      TreatMissingData: ignore

--- a/src/main/scala/payment_failure_comms/Handler.scala
+++ b/src/main/scala/payment_failure_comms/Handler.scala
@@ -35,10 +35,7 @@ object Handler {
       case Left(failure) =>
         Log.failure(logger)(failure)
         throw new RuntimeException(failure.details)
-      case Right(_) =>
-        Log.completion(logger)
-//        TODO remove
-        throw new RuntimeException("Testing 1 2 3")
+      case Right(_) => Log.completion(logger)
     }
   }
 

--- a/src/main/scala/payment_failure_comms/Handler.scala
+++ b/src/main/scala/payment_failure_comms/Handler.scala
@@ -35,7 +35,10 @@ object Handler {
       case Left(failure) =>
         Log.failure(logger)(failure)
         throw new RuntimeException(failure.details)
-      case Right(_) => Log.completion(logger)
+      case Right(_) =>
+        Log.completion(logger)
+//        TODO remove
+        throw new RuntimeException("Testing 1 2 3")
     }
   }
 

--- a/src/main/scala/payment_failure_comms/Handler.scala
+++ b/src/main/scala/payment_failure_comms/Handler.scala
@@ -32,8 +32,10 @@ object Handler {
       )
       _ <- sfConnector.updateRecords(updateRecordsRequest)
     } yield ()) match {
-      case Left(failure) => Log.failure(logger)(failure)
-      case Right(_)      => Log.completion(logger)()
+      case Left(failure) =>
+        Log.failure(logger)(failure)
+        throw new RuntimeException(failure.details)
+      case Right(_) => Log.completion(logger)
     }
   }
 

--- a/src/main/scala/payment_failure_comms/Log.scala
+++ b/src/main/scala/payment_failure_comms/Log.scala
@@ -93,6 +93,6 @@ object Log {
       )
     )
 
-  def completion(logger: LambdaLogger)(): Unit =
+  def completion(logger: LambdaLogger): Unit =
     info(logger)(InfoMessage(event = "Completion"))
 }


### PR DESCRIPTION
This adds an alarm that will go off a minute after any lambda failure in the Prod environment.

Once we have gathered some reasons for it going off, we can tweak the alarm threshold and build up the troubleshooting steps in the Readme.

Tested in Dev.
