### PR TITLE
Refactor configuration

### DIFF
--- a/cfn.yaml
+++ b/cfn.yaml
@@ -21,17 +21,17 @@ Mappings:
   StageMap:
     PROD:
       Schedule: 'rate(30 minutes)'
-      SalesforceStage: DEV
-      SalesforceUsername: pfCommsAPIUser
-      SalesforceAppName: AwsConnectorSandbox
+      SalesforceStage: PROD
+      SalesforceUserName: pfCommsAPIUser
+      SalesforceAppName: PfComms
       IdapiInstanceUrl: idapi.theguardian.com
       IdapiStage: PROD
       BrazeInstanceUrl: rest.fra-01.braze.eu
-      BrazeAppGroup: DEV
+      BrazeAppGroup: LIVE
     CODE:
       Schedule: 'rate(365 days)'
-      SalesforceStage: DEV
-      SalesforceUsername: pfCommsAPIUser
+      SalesforceStage: UAT
+      SalesforceUserName: pfCommsAPIUser
       SalesforceAppName: AwsConnectorSandbox
       IdapiInstanceUrl: idapi.code.dev-theguardian.com
       IdapiStage: CODE
@@ -40,7 +40,7 @@ Mappings:
     DEV:
       Schedule: 'rate(365 days)'
       SalesforceStage: DEV
-      SalesforceUsername: pfCommsAPIUser
+      SalesforceUserName: pfCommsAPIUser
       SalesforceAppName: AwsConnectorSandbox
       IdapiInstanceUrl: idapi.code.dev-theguardian.com
       IdapiStage: CODE
@@ -85,33 +85,33 @@ Resources:
             - '{{resolve:secretsmanager:${SalesforceStage}/Salesforce/ConnectedApp/${SalesforceAppName}:SecretString:clientSecret}}'
             - SalesforceStage: !FindInMap [ StageMap, !Ref Stage, SalesforceStage ]
               SalesforceAppName: !FindInMap [ StageMap, !Ref Stage, SalesforceAppName ]
-          salesforceUsername:
+          salesforceUserName:
             !Sub
-            - '{{resolve:secretsmanager:${SalesforceStage}/Salesforce/User/${SalesforceUsername}:SecretString:sfUsername}}'
+            - '{{resolve:secretsmanager:${SalesforceStage}/Salesforce/User/${SalesforceUserName}:SecretString:userName}}'
             - SalesforceStage: !FindInMap [ StageMap, !Ref Stage, SalesforceStage ]
-              SalesforceUsername: !FindInMap [ StageMap, !Ref Stage, SalesforceUsername ]
+              SalesforceUserName: !FindInMap [ StageMap, !Ref Stage, SalesforceUserName ]
           salesforcePassword:
             !Sub
-            - '{{resolve:secretsmanager:${SalesforceStage}/Salesforce/User/${SalesforceUsername}:SecretString:sfPassword}}'
+            - '{{resolve:secretsmanager:${SalesforceStage}/Salesforce/User/${SalesforceUserName}:SecretString:password}}'
             - SalesforceStage: !FindInMap [ StageMap, !Ref Stage, SalesforceStage ]
-              SalesforceUsername: !FindInMap [ StageMap, !Ref Stage, SalesforceUsername ]
+              SalesforceUserName: !FindInMap [ StageMap, !Ref Stage, SalesforceUserName ]
           salesforceToken:
             !Sub
-            - '{{resolve:secretsmanager:${SalesforceStage}/Salesforce/User/${SalesforceUsername}:SecretString:sfToken}}'
+            - '{{resolve:secretsmanager:${SalesforceStage}/Salesforce/User/${SalesforceUserName}:SecretString:token}}'
             - SalesforceStage: !FindInMap [ StageMap, !Ref Stage, SalesforceStage ]
-              SalesforceUsername: !FindInMap [ StageMap, !Ref Stage, SalesforceUsername ]
+              SalesforceUserName: !FindInMap [ StageMap, !Ref Stage, SalesforceUserName ]
           idapiInstanceUrl: !FindInMap [ StageMap, !Ref Stage, IdapiInstanceUrl ]
           idapiBearerToken: !Sub
-            - '{{resolve:secretsmanager:IDAPI/${IdapiStage}/${AppName}:SecretString:bearerToken}}'
+            - '{{resolve:secretsmanager:${IdapiStage}/Identity/${AppName}:SecretString:bearerToken}}'
             - IdapiStage: !FindInMap [ StageMap, !Ref Stage, IdapiStage ]
           brazeInstanceUrl: !FindInMap [ StageMap, !Ref Stage, BrazeInstanceUrl ]
-          brazeBearerToken:
+          brazeApiKey:
             !Sub
-            - '{{resolve:secretsmanager:Braze/${BrazeAppGroup}/${AppName}:SecretString:bearerToken}}'
+            - '{{resolve:secretsmanager:${BrazeAppGroup}/Braze/${AppName}:SecretString:apiKey}}'
             - BrazeAppGroup: !FindInMap [ StageMap, !Ref Stage, BrazeAppGroup ]
-          zuoraAppIdForBraze:
+          appIdForBraze:
             !Sub
-            - '{{resolve:secretsmanager:Braze/${BrazeAppGroup}/${AppName}:SecretString:zuoraAppId}}'
+            - '{{resolve:secretsmanager:${BrazeAppGroup}/Braze/${AppName}:SecretString:appId}}'
             - BrazeAppGroup: !FindInMap [ StageMap, !Ref Stage, BrazeAppGroup ]
       Events:
         ScheduledRun:

--- a/src/main/scala/payment_failure_comms/TestEventLoader.scala
+++ b/src/main/scala/payment_failure_comms/TestEventLoader.scala
@@ -49,9 +49,9 @@ object TestEventLoader extends App {
   private val maybeBrazeConfig =
     for {
       brazeInstanceUrl <- getFromEnv("brazeInstanceUrl")
-      brazeBearerToken <- getFromEnv("brazeBearerToken")
-      brazeZuoraAppId <- getFromEnv("zuoraAppIdForBraze")
-    } yield BrazeConfig(brazeInstanceUrl, brazeBearerToken, brazeZuoraAppId)
+      brazeApiKey <- getFromEnv("brazeApiKey")
+      brazeZuoraAppId <- getFromEnv("appIdForBraze")
+    } yield BrazeConfig(brazeInstanceUrl, brazeApiKey, brazeZuoraAppId)
 
   private def createAccount(config: BrazeConfig) =
     new Request.Builder()

--- a/src/main/scala/payment_failure_comms/models/Config.scala
+++ b/src/main/scala/payment_failure_comms/models/Config.scala
@@ -27,12 +27,12 @@ object Config {
       salesforceApiVersion <- getFromEnv("salesforceApiVersion")
       salesforceClientId <- getFromEnv("salesforceClientId")
       salesforceClientSecret <- getFromEnv("salesforceClientSecret")
-      salesforceUsername <- getFromEnv("salesforceUsername")
+      salesforceUsername <- getFromEnv("salesforceUserName")
       salesforcePassword <- getFromEnv("salesforcePassword")
       salesforceToken <- getFromEnv("salesforceToken")
       brazeInstanceUrl <- getFromEnv("brazeInstanceUrl")
-      brazeBearerToken <- getFromEnv("brazeBearerToken")
-      brazeZuoraAppId <- getFromEnv("zuoraAppIdForBraze")
+      brazeApiKey <- getFromEnv("brazeApiKey")
+      appIdForBraze <- getFromEnv("appIdForBraze")
       idapiInstanceUrl <- getFromEnv("idapiInstanceUrl")
       idapiBearerToken <- getFromEnv("idapiBearerToken")
     } yield Config(
@@ -46,7 +46,7 @@ object Config {
         salesforceToken
       ),
       IdapiConfig(idapiInstanceUrl, idapiBearerToken),
-      BrazeConfig(brazeInstanceUrl, brazeBearerToken, brazeZuoraAppId)
+      BrazeConfig(brazeInstanceUrl, brazeApiKey, appIdForBraze)
     )
   }
 }


### PR DESCRIPTION
Some configuration has been renamed to follow conventions.
* We name secrets in Secrets Manager in format `stage/system/optional subsystem/name` and the code has been changed to reflect this
* Prod settings have been updated to real names
* Braze has `Dev` and `Live` stages so the code has been changed to reflect this
* The Braze bearer token is referred to as an API key in Braze itself.
