### PR TITLE
Support contact records with no Identity ID

### DIFF
--- a/src/main/scala/payment_failure_comms/SalesforceConnector.scala
+++ b/src/main/scala/payment_failure_comms/SalesforceConnector.scala
@@ -51,6 +51,7 @@ object SalesforceConnector {
       """
       |SELECT 
       |  Id,
+      |  Contact__c,
       |  Contact__r.IdentityID__c,
       |  SF_Subscription__r.Product_Name__c,
       |  SF_Subscription__r.Cancellation_Request_Date__c,

--- a/src/main/scala/payment_failure_comms/models/PaymentFailureRecord.scala
+++ b/src/main/scala/payment_failure_comms/models/PaymentFailureRecord.scala
@@ -4,6 +4,7 @@ import java.time.{LocalDate, OffsetDateTime}
 
 case class PaymentFailureRecord(
     Id: String,
+    Contact__c: String,
     Contact__r: SFContact,
     SF_Subscription__r: SFSubscription,
     PF_Comms_Status__c: String,
@@ -16,7 +17,7 @@ case class PaymentFailureRecord(
     Cut_Off_Date__c: LocalDate
 )
 
-case class SFContact(IdentityID__c: String)
+case class SFContact(IdentityID__c: Option[String])
 
 case class SFSubscription(
     Product_Name__c: String,

--- a/src/test/scala/payment_failure_comms/models/BrazeTrackRequestTest.scala
+++ b/src/test/scala/payment_failure_comms/models/BrazeTrackRequestTest.scala
@@ -11,7 +11,8 @@ class BrazeTrackRequestTest extends AnyFlatSpec with should.Matchers {
     PaymentFailureRecordWithBrazeId(
       record = PaymentFailureRecord(
         Id = id.toString,
-        Contact__r = SFContact(IdentityID__c = "i1"),
+        Contact__c = "c7",
+        Contact__r = SFContact(IdentityID__c = Some("i1")),
         SF_Subscription__r = SFSubscription(
           Product_Name__c = "prod1",
           Cancellation_Request_Date__c = Some(OffsetDateTime.of(2021, 10, 25, 11, 15, 1, 0, ZoneOffset.ofHours(1)))


### PR DESCRIPTION
There are many contact records in Salesforce without Identity IDs so we can't assume that it will be there.

This change makes the field optional and there is a change to the logic of determining the Braze account ID from the contact.  Where the contact has no Identity ID we use the ID of the contact record as the Braze account ID.  This matches existing accounts in Braze because it's an established pattern for dealing with cases where there's no Identity ID to match on.
