### PR TITLE
Support optional custom_events field in Braze /users/export/ids response

### DIFF
--- a/src/main/scala/payment_failure_comms/models/BrazeUserData.scala
+++ b/src/main/scala/payment_failure_comms/models/BrazeUserData.scala
@@ -6,7 +6,7 @@ import java.time.ZonedDateTime
  * Braze response model for /users/export/id endpoint, serialized as Json.
  */
 case class BrazeUserResponse(users: Seq[User])
-case class User(external_id: String, custom_events: Seq[UserCustomEvent])
+case class User(external_id: String, custom_events: Option[Seq[UserCustomEvent]])
 case class UserCustomEvent(name: String, first: ZonedDateTime, last: ZonedDateTime, count: Int)
 
 /*

--- a/src/test/scala/payment_failure_comms/models/BrazeTrackRequestTest.scala
+++ b/src/test/scala/payment_failure_comms/models/BrazeTrackRequestTest.scala
@@ -107,12 +107,14 @@ class BrazeTrackRequestTest extends AnyFlatSpec with should.Matchers {
       Seq(
         User(
           external_id = "ei2",
-          custom_events = Seq(
-            UserCustomEvent(
-              name = "payment_recovery",
-              first = ZonedDateTime.of(2019, 10, 10, 4, 6, 12, 0, ZoneId.of("UTC")),
-              last = ZonedDateTime.of(2020, 2, 3, 4, 5, 6, 0, ZoneId.of("UTC")),
-              count = 3
+          custom_events = Some(
+            Seq(
+              UserCustomEvent(
+                name = "payment_recovery",
+                first = ZonedDateTime.of(2019, 10, 10, 4, 6, 12, 0, ZoneId.of("UTC")),
+                last = ZonedDateTime.of(2020, 2, 3, 4, 5, 6, 0, ZoneId.of("UTC")),
+                count = 3
+              )
             )
           )
         )
@@ -143,12 +145,14 @@ class BrazeTrackRequestTest extends AnyFlatSpec with should.Matchers {
       Seq(
         User(
           external_id = "ei1",
-          custom_events = Seq(
-            UserCustomEvent(
-              name = "payment_failure",
-              first = ZonedDateTime.of(2019, 10, 10, 4, 6, 12, 0, ZoneId.of("UTC")),
-              last = ZonedDateTime.of(2021, 10, 26, 11, 15, 27, 0, ZoneId.of("UTC")),
-              count = 3
+          custom_events = Some(
+            Seq(
+              UserCustomEvent(
+                name = "payment_failure",
+                first = ZonedDateTime.of(2019, 10, 10, 4, 6, 12, 0, ZoneId.of("UTC")),
+                last = ZonedDateTime.of(2021, 10, 26, 11, 15, 27, 0, ZoneId.of("UTC")),
+                count = 3
+              )
             )
           )
         )
@@ -171,12 +175,14 @@ class BrazeTrackRequestTest extends AnyFlatSpec with should.Matchers {
       Seq(
         User(
           external_id = "ei1",
-          custom_events = Seq(
-            UserCustomEvent(
-              name = "payment_recovery",
-              first = ZonedDateTime.of(2019, 10, 10, 4, 6, 12, 0, ZoneId.of("UTC")),
-              last = ZonedDateTime.of(2021, 10, 26, 11, 15, 27, 0, ZoneId.of("UTC")),
-              count = 3
+          custom_events = Some(
+            Seq(
+              UserCustomEvent(
+                name = "payment_recovery",
+                first = ZonedDateTime.of(2019, 10, 10, 4, 6, 12, 0, ZoneId.of("UTC")),
+                last = ZonedDateTime.of(2021, 10, 26, 11, 15, 27, 0, ZoneId.of("UTC")),
+                count = 3
+              )
             )
           )
         )
@@ -207,12 +213,14 @@ class BrazeTrackRequestTest extends AnyFlatSpec with should.Matchers {
       Seq(
         User(
           external_id = "ei1",
-          custom_events = Seq(
-            UserCustomEvent(
-              name = "payment_failure",
-              first = ZonedDateTime.of(2019, 10, 10, 4, 6, 12, 0, ZoneId.of("UTC")),
-              last = ZonedDateTime.of(2020, 10, 26, 11, 15, 27, 0, ZoneId.of("UTC")),
-              count = 3
+          custom_events = Some(
+            Seq(
+              UserCustomEvent(
+                name = "payment_failure",
+                first = ZonedDateTime.of(2019, 10, 10, 4, 6, 12, 0, ZoneId.of("UTC")),
+                last = ZonedDateTime.of(2020, 10, 26, 11, 15, 27, 0, ZoneId.of("UTC")),
+                count = 3
+              )
             )
           )
         )
@@ -243,12 +251,14 @@ class BrazeTrackRequestTest extends AnyFlatSpec with should.Matchers {
       Seq(
         User(
           external_id = "ei1",
-          custom_events = Seq(
-            UserCustomEvent(
-              name = "payment_failure",
-              first = ZonedDateTime.of(2019, 10, 10, 4, 6, 12, 0, ZoneId.of("UTC")),
-              last = ZonedDateTime.of(2021, 10, 27, 11, 15, 27, 0, ZoneId.of("UTC")),
-              count = 3
+          custom_events = Some(
+            Seq(
+              UserCustomEvent(
+                name = "payment_failure",
+                first = ZonedDateTime.of(2019, 10, 10, 4, 6, 12, 0, ZoneId.of("UTC")),
+                last = ZonedDateTime.of(2021, 10, 27, 11, 15, 27, 0, ZoneId.of("UTC")),
+                count = 3
+              )
             )
           )
         )


### PR DESCRIPTION
The response from Braze to a `/users/export/ids` request has an optional `custom_events` field which we have modelled as a required field.  This change corrects that by making the field optional and then modifying the use of it to find the diff with a given collection of incoming `CustomEvent`s.
