### PR TITLE
Avoid Braze concurrent update limit

### DIFF
--- a/src/main/scala/payment_failure_comms/SalesforceConnector.scala
+++ b/src/main/scala/payment_failure_comms/SalesforceConnector.scala
@@ -46,7 +46,11 @@ object SalesforceConnector {
       apiVersion: String,
       logger: LambdaLogger
   ): Either[Failure, Seq[PaymentFailureRecord]] = {
-    // Query limited to 200 records to avoid Salesforce's governor limits on number of requests per response
+    /*
+     * Query limited to 50 records to avoid hitting the limit for concurrent updates
+     * using the Braze user track endpoint.
+     * See https://www.braze.com/docs/api/errors/#fatal-errors
+     */
     val query =
       """
       |SELECT 
@@ -70,7 +74,7 @@ object SalesforceConnector {
       |  'Ready to send voluntary cancel event',
       |  'Ready to send auto cancel event'
       |)
-      |LIMIT 200""".stripMargin
+      |LIMIT 50""".stripMargin
 
     handleRequestResult[SFPaymentFailureRecordWrapper](logger)(
       responseToQueryRequest(


### PR DESCRIPTION
This reduces the number of payment-failure records we read from Salesforce to 50 as that is the update limit for a single request in Braze.
It would be possible to fetch more and process them in multiple writes to Braze but that would add complexity to the code.  So keeping it simple and just reading from Salesforce more often.