### PR TITLE
Enable scheduled run in Prod

### DIFF
--- a/cfn.yaml
+++ b/cfn.yaml
@@ -20,7 +20,7 @@ Conditions:
 Mappings:
   StageMap:
     PROD:
-      Schedule: 'rate(30 minutes)'
+      Schedule: 'rate(20 minutes)'
       SalesforceStage: PROD
       SalesforceUserName: pfCommsAPIUser
       SalesforceAppName: PfComms
@@ -117,9 +117,12 @@ Resources:
         ScheduledRun:
           Type: Schedule
           Properties:
-            Schedule: !FindInMap [ StageMap, !Ref Stage, Schedule ]
             Description: Send payment failure communications
-            Enabled: False
+            Schedule: !FindInMap [ StageMap, !Ref Stage, Schedule ]
+            RetryPolicy:
+              # As process runs every 20 mins anyway, there's no point in retrying on failure
+              MaximumRetryAttempts: 0
+            Enabled: True
 
   FailureAlarm:
     Type: AWS::CloudWatch::Alarm


### PR DESCRIPTION
This enables the lambda to run in Prod every 20 mins.
I've increased the number of runs as we now read fewer in a batch because of #64.

Lambdas automatically retry twice on failure but I've disabled that as we are running every 20 mins anyway.
