### PR TITLE
Increase connect timeout to 30 s

### DIFF
--- a/src/main/scala/payment_failure_comms/BrazeConnector.scala
+++ b/src/main/scala/payment_failure_comms/BrazeConnector.scala
@@ -12,7 +12,6 @@ import scala.util.Try
 object BrazeConnector {
 
   private val JSON: MediaType = MediaType.get("application/json; charset=utf-8")
-  private val http = new OkHttpClient()
 
   def fetchCustomEvents(brazeConfig: BrazeConfig, logger: LambdaLogger)(
       payload: BrazeUserRequest
@@ -81,7 +80,7 @@ object BrazeConnector {
     )
 
     Try(
-      http.newCall(request).execute()
+      HttpClient().newCall(request).execute()
     ).toEither
   }
 

--- a/src/main/scala/payment_failure_comms/HttpClient.scala
+++ b/src/main/scala/payment_failure_comms/HttpClient.scala
@@ -1,0 +1,15 @@
+package payment_failure_comms
+
+import okhttp3.OkHttpClient
+
+import java.util.concurrent.TimeUnit.SECONDS
+
+object HttpClient {
+
+  private val client = new OkHttpClient.Builder()
+    .connectTimeout(30, SECONDS)
+    .readTimeout(30, SECONDS)
+    .build()
+
+  def apply(): OkHttpClient = client
+}

--- a/src/main/scala/payment_failure_comms/IdapiConnector.scala
+++ b/src/main/scala/payment_failure_comms/IdapiConnector.scala
@@ -11,8 +11,6 @@ import scala.util.Try
 
 object IdapiConnector {
 
-  private val http = new OkHttpClient()
-
   def getBrazeId(idapiConfig: IdapiConfig, logger: LambdaLogger)(IdentityId: String): Either[Failure, String] = {
     handleRequestResult[IdapiGetUserResponse](logger)(
       responseToGetRequest(logger)(
@@ -36,7 +34,7 @@ object IdapiConnector {
     )
 
     Try(
-      http.newCall(request).execute()
+      HttpClient().newCall(request).execute()
     ).toEither
   }
 

--- a/src/main/scala/payment_failure_comms/SalesforceConnector.scala
+++ b/src/main/scala/payment_failure_comms/SalesforceConnector.scala
@@ -25,7 +25,6 @@ object SalesforceConnector {
 
   private val urlEncoded = MediaType.parse("application/x-www-form-urlencoded")
   private val JSON: MediaType = MediaType.get("application/json; charset=utf-8")
-  private val http = new OkHttpClient()
 
   implicit val salesforceDateTimeDecoder: Decoder[OffsetDateTime] =
     Decoder.decodeOffsetDateTimeWithFormatter(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSxx"))
@@ -134,7 +133,7 @@ object SalesforceConnector {
     )
 
     Try(
-      http.newCall(request).execute()
+      HttpClient().newCall(request).execute()
     ).toEither
   }
 
@@ -166,7 +165,7 @@ object SalesforceConnector {
     )
 
     Try(
-      http.newCall(request).execute()
+      HttpClient().newCall(request).execute()
     ).toEither
   }
 
@@ -188,7 +187,7 @@ object SalesforceConnector {
     )
 
     Try(
-      http.newCall(request).execute()
+      HttpClient().newCall(request).execute()
     ).toEither
   }
 


### PR DESCRIPTION
We were seeing occasional timeout errors reading from Salesforce.
So this increases connection and read timeouts from the default 10 s to 30 s.
