### PR TITLE
Optimise filter on Salesforce read query

### DIFF
--- a/src/main/scala/payment_failure_comms/SalesforceConnector.scala
+++ b/src/main/scala/payment_failure_comms/SalesforceConnector.scala
@@ -47,6 +47,8 @@ object SalesforceConnector {
      * Query limited to 50 records to avoid hitting the limit for concurrent updates
      * using the Braze user track endpoint.
      * See https://www.braze.com/docs/api/errors/#fatal-errors
+     *
+     * Including Status_Helper__c field in query to improve its filtering efficiency and, therefore, performance.
      */
     val query =
       """
@@ -65,7 +67,14 @@ object SalesforceConnector {
       |  Last_Attempt_Date__c,
       |  Cut_Off_Date__c
       |FROM Payment_Failure__c
-      |WHERE PF_Comms_Status__c
+      |WHERE Status_Helper__c
+      |IN (
+      |  'payment outstanding',
+      |  'recovered',
+      |  'cancelled-customer',
+      |  'cancelled-auto'
+      |)
+      |AND PF_Comms_Status__c
       |IN (
       |  'Ready to send entry event',
       |  'Ready to send recovery event',


### PR DESCRIPTION
The query was filtering on a formula field, which was performing badly and creating timeouts on the client.
Now it filters on another non-formula field first, `Status_Helper__c`, which means that the formula field has only to apply to a restricted subset of the table.  This appears to at least halve the duration of the query in the Salesforce console.

Works in Code.
