### PR TITLE
Increase alarm threshold

### DIFF
--- a/cfn.yaml
+++ b/cfn.yaml
@@ -141,8 +141,8 @@ Resources:
         - Name: FunctionName
           Value: !Ref PaymentFailureCommsLambda
       ComparisonOperator: GreaterThanOrEqualToThreshold
-      Threshold: 1
+      Threshold: 3
       Statistic: Sum
-      Period: 60
+      Period: 3600
       EvaluationPeriods: 1
       TreatMissingData: ignore


### PR DESCRIPTION
To trigger alarm after 3 failures per hour rather than one.

This is because we're seeing occasional timeouts but the read always succeeds eventually.
