### PR TITLE
Gather info about a PR from a fork

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,10 @@ jobs:
       contents: read
 
     steps:
+    
+      - name: Dump GitHub context
+        run: echo '${{ toJSON(github) }}'
+        
       - name: Checkout repo
         uses: actions/checkout@v2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,8 @@ jobs:
     steps:
     
       - name: Dump GitHub context
-        run: echo "${{toJSON(github)}}"
+        id: github_context_step
+        run: echo '${{toJSON(github)}}'
         
       - name: Checkout repo
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
     
       - name: Dump GitHub context
-        run: echo '${{ toJSON(github) }}'
+        run: echo ${{ toJSON(github) }}
         
       - name: Checkout repo
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
     
       - name: Dump GitHub context
-        run: echo ${{ toJSON(github) }}
+        run: echo "${{ toJSON(github) }}"
         
       - name: Checkout repo
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
     
       - name: Dump GitHub context
-        run: echo '${{toJSON(github)}}'
+        run: echo "${{toJSON(github)}}"
         
       - name: Checkout repo
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
     
       - name: Dump GitHub context
-        run: echo "${{ toJSON(github) }}"
+        run: echo '${{toJSON(github)}}'
         
       - name: Checkout repo
         uses: actions/checkout@v2


### PR DESCRIPTION
Log the github object so that we can see what to restrict.

PRs from forks fail so they are safe but it would be nice not to even try to run the workflow when a PR comes from a fork.
By default, a fork doesn't have access to a repo's secrets.
See https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows
