### PR TITLE
Tighten conditions for running CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,10 @@ on:
 jobs:
   CI:
 
-    if: github.actor != 'scala-steward'
+    if: >
+      github.event_name = 'push' || 
+      github.event_name = 'workflow_dispatch' || 
+      (github.event_name = 'pull_request' && github.event.pull_request.head.repo.owner.login = 'guardian')
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,9 @@ jobs:
   CI:
 
     if: >
-      github.event_name = 'push' || 
-      github.event_name = 'workflow_dispatch' || 
-      (github.event_name = 'pull_request' && github.event.pull_request.head.repo.owner.login = 'guardian')
+      github.event_name == 'push' || 
+      github.event_name == 'workflow_dispatch' || 
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.owner.login == 'guardian')
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
This should skip the CI workflow when a PR is raised from a fork.

Inspecting the content of the `github` object, `github.event.pull_request.head.repo.owner.login` seems to be the most obvious identifier of the source repo.
