### PR TITLE
Correct isPrFromForkedRepo condition

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
       - main
 
 env:
-  isPrFromForkedRepo: ${{ github.event.pull_request.head.repo.owner.login != 'guardian' }}
+  isPrFromForkedRepo: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.owner.login != 'guardian' }}
 
 jobs:
   CI:


### PR DESCRIPTION
We need to include the PR event as part of the condition, otherwise a push to main will also be seen as a PR from a forked repo.