### PR TITLE
Make product name optional in model

### DIFF
--- a/src/main/scala/payment_failure_comms/models/PaymentFailureRecord.scala
+++ b/src/main/scala/payment_failure_comms/models/PaymentFailureRecord.scala
@@ -26,7 +26,8 @@ case class SFPayment(Zuora__GatewayResponseCode__c: String, Zuora__GatewayRespon
 case class SFContact(IdentityID__c: Option[String], FirstName: String, LastName: String)
 
 case class SFSubscription(
-    Product_Name__c: String,
+    // Although this field should be required, there are records in Salesforce with a null value.
+    Product_Name__c: Option[String] = None,
     Zuora_Subscription_Name__c: String,
     Cancellation_Request_Date__c: Option[OffsetDateTime] = None
 )

--- a/src/main/scala/payment_failure_comms/models/brazeTrackEvents.scala
+++ b/src/main/scala/payment_failure_comms/models/brazeTrackEvents.scala
@@ -126,7 +126,7 @@ object BrazeTrackRequest {
           ResponseMessageAttr(record.brazeId, Initial_Payment__r.Zuora__GatewayResponse__c),
           LastAttemptDateAttr(record.brazeId, Last_Attempt_Date__c),
           SubscriptionIdAttr(record.brazeId, SF_Subscription__r.Zuora_Subscription_Name__c),
-          ProductNameAttr(record.brazeId, SF_Subscription__r.Product_Name__c),
+          ProductNameAttr(record.brazeId, SF_Subscription__r.Product_Name__c.getOrElse("")),
           InvoiceCreatedDateAttr(record.brazeId, Invoice_Created_Date__c),
           BillToCountryAttr(record.brazeId, record.record.Billing_Account__r.Zuora__BillToCountry__c)
         ),
@@ -136,7 +136,7 @@ object BrazeTrackRequest {
           name = eventName,
           time = eventTime,
           properties = EventProperties(
-            product = SF_Subscription__r.Product_Name__c,
+            product = SF_Subscription__r.Product_Name__c.getOrElse(""),
             currency = record.record.Currency__c,
             amount = record.record.Invoice_Total_Amount__c
           )

--- a/src/test/scala/payment_failure_comms/models/BrazeTrackRequestTest.scala
+++ b/src/test/scala/payment_failure_comms/models/BrazeTrackRequestTest.scala
@@ -14,7 +14,7 @@ class BrazeTrackRequestTest extends AnyFlatSpec with should.Matchers {
         Contact__c = "c7",
         Contact__r = SFContact(IdentityID__c = Some("i1"), FirstName = "Jon", LastName = "Richards"),
         SF_Subscription__r = SFSubscription(
-          Product_Name__c = "prod1",
+          Product_Name__c = Some("prod1"),
           Zuora_Subscription_Name__c = "A-S87234234",
           Cancellation_Request_Date__c = Some(OffsetDateTime.of(2021, 10, 25, 11, 15, 1, 0, ZoneOffset.ofHours(1)))
         ),


### PR DESCRIPTION
Although the product name should always have a value, that can't be relied on as there are several cases where subscriptions have no product name.  Rather than clean up all the data and the generating code in Salesforce, it will be easier to make the field optional in the model here.

Because we export the records in a single structure, if a single one fails to be deserialised there will be an ever-growing buildup so even though this is a very rare occurrence it will block the whole system.
