### PR TITLE
Temporarily increase number of lambda runs

### DIFF
--- a/cfn.yaml
+++ b/cfn.yaml
@@ -20,7 +20,7 @@ Conditions:
 Mappings:
   StageMap:
     PROD:
-      Schedule: 'rate(20 minutes)'
+      Schedule: 'rate(3 minutes)'
       SalesforceStage: PROD
       SalesforceUserName: pfCommsAPIUser
       SalesforceAppName: PfComms


### PR DESCRIPTION
This is a temporary change to get through the backlog.

There are currently 4,297 records to process.
Each run takes 50 so can process all in 86 runs, which would take < 5 hours if running every 3 mins.

The longest run has taken ~ 90 s so they won't be running concurrently.

Depends on #101 
