### PR TITLE
Order payment-failure records by invoice date

### DIFF
--- a/src/main/scala/payment_failure_comms/SalesforceConnector.scala
+++ b/src/main/scala/payment_failure_comms/SalesforceConnector.scala
@@ -87,6 +87,7 @@ object SalesforceConnector {
       |  'Ready to send voluntary cancel event',
       |  'Ready to send auto cancel event'
       |)
+      |ORDER BY Invoice_Created_Date__c
       |LIMIT 50""".stripMargin
 
     handleRequestResult[SFPaymentFailureRecordWrapper](logger)(


### PR DESCRIPTION
This is to ensure that any backlog is cleared in the right order.
I see that there are still some to clear from 21 Feb.
