### PR TITLE
Speed up backlog clearance

### DIFF
--- a/cfn.yaml
+++ b/cfn.yaml
@@ -20,7 +20,7 @@ Conditions:
 Mappings:
   StageMap:
     PROD:
-      Schedule: 'rate(3 minutes)'
+      Schedule: 'rate(1 minutes)'
       SalesforceStage: PROD
       SalesforceUserName: pfCommsAPIUser
       SalesforceAppName: PfComms


### PR DESCRIPTION
The longest run in the past 24 hours took 33 seconds so it seems safe to temporarily increase to run every minute.
Then will switch back to run every 20 minutes when the backlog is clear.