### PR TITLE
Send multiple requests to Braze so we do not hit attribute limit

### DIFF
--- a/src/test/scala/payment_failure_comms/models/BrazeTrackRequestTest.scala
+++ b/src/test/scala/payment_failure_comms/models/BrazeTrackRequestTest.scala
@@ -42,7 +42,7 @@ class BrazeTrackRequestTest extends AnyFlatSpec with should.Matchers {
       records = Nil,
       zuoraAppId = "z1",
       eventsAlreadyWritten = BrazeUserResponse(Nil)
-    ) shouldBe Right(BrazeTrackRequest(Nil, Nil))
+    ) shouldBe Right(Seq())
   }
 
   val eventProperties = EventProperties(product = "prod1", currency = "GBP", amount = 1.2)
@@ -57,54 +57,272 @@ class BrazeTrackRequestTest extends AnyFlatSpec with should.Matchers {
       zuoraAppId = "z1",
       eventsAlreadyWritten = BrazeUserResponse(Nil)
     ) shouldBe Right(
-      BrazeTrackRequest(
-        attributes = Seq(
-          PaymentFailureTypeAttr("b1", Some("Credit Card")),
-          ResponseCodeAttr("b1", Some("generic_decline")),
-          ResponseMessageAttr("b1", Some("Your card was declined.")),
-          LastAttemptDateAttr("b1", Some(LocalDate.of(2021, 10, 26))),
-          SubscriptionIdAttr("b1", Some("A-S87234234")),
-          ProductNameAttr("b1", "prod1"),
-          InvoiceCreatedDateAttr("b1", Some(LocalDate.of(2021, 10, 26))),
-          BillToCountryAttr("b1", Some("United Kingdom")),
-          PaymentFailureTypeAttr("b2", Some("Credit Card")),
-          ResponseCodeAttr("b2", Some("generic_decline")),
-          ResponseMessageAttr("b2", Some("Your card was declined.")),
-          LastAttemptDateAttr("b2", Some(LocalDate.of(2021, 10, 26))),
-          SubscriptionIdAttr("b2", Some("A-S87234234")),
-          ProductNameAttr("b2", "prod1"),
-          InvoiceCreatedDateAttr("b2", Some(LocalDate.of(2021, 10, 26))),
-          BillToCountryAttr("b2", Some("United Kingdom")),
-          PaymentFailureTypeAttr("b3", Some("Credit Card")),
-          ResponseCodeAttr("b3", Some("generic_decline")),
-          ResponseMessageAttr("b3", Some("Your card was declined.")),
-          LastAttemptDateAttr("b3", Some(LocalDate.of(2021, 10, 26))),
-          SubscriptionIdAttr("b3", Some("A-S87234234")),
-          ProductNameAttr("b3", "prod1"),
-          InvoiceCreatedDateAttr("b3", Some(LocalDate.of(2021, 10, 26))),
-          BillToCountryAttr("b3", Some("United Kingdom"))
+      Seq(
+        BrazeTrackRequest(
+          Seq(
+            PaymentFailureTypeAttr("b1", Some("Credit Card")),
+            ResponseCodeAttr("b1", Some("generic_decline")),
+            ResponseMessageAttr("b1", Some("Your card was declined.")),
+            LastAttemptDateAttr("b1", Some(LocalDate.of(2021, 10, 26))),
+            SubscriptionIdAttr("b1", Some("A-S87234234")),
+            ProductNameAttr("b1", "prod1"),
+            InvoiceCreatedDateAttr("b1", Some(LocalDate.of(2021, 10, 26))),
+            BillToCountryAttr("b1", Some("United Kingdom")),
+            PaymentFailureTypeAttr("b2", Some("Credit Card")),
+            ResponseCodeAttr("b2", Some("generic_decline")),
+            ResponseMessageAttr("b2", Some("Your card was declined.")),
+            LastAttemptDateAttr("b2", Some(LocalDate.of(2021, 10, 26))),
+            SubscriptionIdAttr("b2", Some("A-S87234234")),
+            ProductNameAttr("b2", "prod1"),
+            InvoiceCreatedDateAttr("b2", Some(LocalDate.of(2021, 10, 26))),
+            BillToCountryAttr("b2", Some("United Kingdom")),
+            PaymentFailureTypeAttr("b3", Some("Credit Card")),
+            ResponseCodeAttr("b3", Some("generic_decline")),
+            ResponseMessageAttr("b3", Some("Your card was declined.")),
+            LastAttemptDateAttr("b3", Some(LocalDate.of(2021, 10, 26))),
+            SubscriptionIdAttr("b3", Some("A-S87234234")),
+            ProductNameAttr("b3", "prod1"),
+            InvoiceCreatedDateAttr("b3", Some(LocalDate.of(2021, 10, 26))),
+            BillToCountryAttr("b3", Some("United Kingdom"))
+          ),
+          Seq(
+            CustomEvent(
+              external_id = "b1",
+              app_id = "z1",
+              name = "pf_recovery",
+              time = "2021-10-26T00:00:00Z",
+              properties = eventProperties
+            ),
+            CustomEvent(
+              external_id = "b2",
+              app_id = "z1",
+              name = "pf_cancel_voluntary",
+              time = "2021-10-25T10:15:01Z",
+              properties = eventProperties
+            ),
+            CustomEvent(
+              external_id = "b3",
+              app_id = "z1",
+              name = "pf_cancel_auto",
+              time = "2021-10-27T00:00:00Z",
+              properties = eventProperties
+            )
+          )
+        )
+      )
+    )
+  }
+
+  it should "return multiple BrazeTrackRequest instances if more than 9 records" in {
+    BrazeTrackRequest(
+      records = Seq(
+        mkPaymentFailureRecord(1, "Ready to send recovery event"),
+        mkPaymentFailureRecord(2, "Ready to send voluntary cancel event"),
+        mkPaymentFailureRecord(3, "Ready to send auto cancel event"),
+        mkPaymentFailureRecord(4, "Ready to send recovery event"),
+        mkPaymentFailureRecord(5, "Ready to send voluntary cancel event"),
+        mkPaymentFailureRecord(6, "Ready to send auto cancel event"),
+        mkPaymentFailureRecord(7, "Ready to send recovery event"),
+        mkPaymentFailureRecord(8, "Ready to send voluntary cancel event"),
+        mkPaymentFailureRecord(9, "Ready to send auto cancel event"),
+        mkPaymentFailureRecord(10, "Ready to send recovery event"),
+        mkPaymentFailureRecord(11, "Ready to send voluntary cancel event"),
+        mkPaymentFailureRecord(12, "Ready to send auto cancel event")
+      ),
+      zuoraAppId = "z1",
+      eventsAlreadyWritten = BrazeUserResponse(Nil)
+    ) shouldBe Right(
+      Seq(
+        BrazeTrackRequest(
+          Seq(
+            PaymentFailureTypeAttr("b1", Some("Credit Card")),
+            ResponseCodeAttr("b1", Some("generic_decline")),
+            ResponseMessageAttr("b1", Some("Your card was declined.")),
+            LastAttemptDateAttr("b1", Some(LocalDate.of(2021, 10, 26))),
+            SubscriptionIdAttr("b1", Some("A-S87234234")),
+            ProductNameAttr("b1", "prod1"),
+            InvoiceCreatedDateAttr("b1", Some(LocalDate.of(2021, 10, 26))),
+            BillToCountryAttr("b1", Some("United Kingdom")),
+            PaymentFailureTypeAttr("b2", Some("Credit Card")),
+            ResponseCodeAttr("b2", Some("generic_decline")),
+            ResponseMessageAttr("b2", Some("Your card was declined.")),
+            LastAttemptDateAttr("b2", Some(LocalDate.of(2021, 10, 26))),
+            SubscriptionIdAttr("b2", Some("A-S87234234")),
+            ProductNameAttr("b2", "prod1"),
+            InvoiceCreatedDateAttr("b2", Some(LocalDate.of(2021, 10, 26))),
+            BillToCountryAttr("b2", Some("United Kingdom")),
+            PaymentFailureTypeAttr("b3", Some("Credit Card")),
+            ResponseCodeAttr("b3", Some("generic_decline")),
+            ResponseMessageAttr("b3", Some("Your card was declined.")),
+            LastAttemptDateAttr("b3", Some(LocalDate.of(2021, 10, 26))),
+            SubscriptionIdAttr("b3", Some("A-S87234234")),
+            ProductNameAttr("b3", "prod1"),
+            InvoiceCreatedDateAttr("b3", Some(LocalDate.of(2021, 10, 26))),
+            BillToCountryAttr("b3", Some("United Kingdom")),
+            PaymentFailureTypeAttr("b4", Some("Credit Card")),
+            ResponseCodeAttr("b4", Some("generic_decline")),
+            ResponseMessageAttr("b4", Some("Your card was declined.")),
+            LastAttemptDateAttr("b4", Some(LocalDate.of(2021, 10, 26))),
+            SubscriptionIdAttr("b4", Some("A-S87234234")),
+            ProductNameAttr("b4", "prod1"),
+            InvoiceCreatedDateAttr("b4", Some(LocalDate.of(2021, 10, 26))),
+            BillToCountryAttr("b4", Some("United Kingdom")),
+            PaymentFailureTypeAttr("b5", Some("Credit Card")),
+            ResponseCodeAttr("b5", Some("generic_decline")),
+            ResponseMessageAttr("b5", Some("Your card was declined.")),
+            LastAttemptDateAttr("b5", Some(LocalDate.of(2021, 10, 26))),
+            SubscriptionIdAttr("b5", Some("A-S87234234")),
+            ProductNameAttr("b5", "prod1"),
+            InvoiceCreatedDateAttr("b5", Some(LocalDate.of(2021, 10, 26))),
+            BillToCountryAttr("b5", Some("United Kingdom")),
+            PaymentFailureTypeAttr("b6", Some("Credit Card")),
+            ResponseCodeAttr("b6", Some("generic_decline")),
+            ResponseMessageAttr("b6", Some("Your card was declined.")),
+            LastAttemptDateAttr("b6", Some(LocalDate.of(2021, 10, 26))),
+            SubscriptionIdAttr("b6", Some("A-S87234234")),
+            ProductNameAttr("b6", "prod1"),
+            InvoiceCreatedDateAttr("b6", Some(LocalDate.of(2021, 10, 26))),
+            BillToCountryAttr("b6", Some("United Kingdom")),
+            PaymentFailureTypeAttr("b7", Some("Credit Card")),
+            ResponseCodeAttr("b7", Some("generic_decline")),
+            ResponseMessageAttr("b7", Some("Your card was declined.")),
+            LastAttemptDateAttr("b7", Some(LocalDate.of(2021, 10, 26))),
+            SubscriptionIdAttr("b7", Some("A-S87234234")),
+            ProductNameAttr("b7", "prod1"),
+            InvoiceCreatedDateAttr("b7", Some(LocalDate.of(2021, 10, 26))),
+            BillToCountryAttr("b7", Some("United Kingdom")),
+            PaymentFailureTypeAttr("b8", Some("Credit Card")),
+            ResponseCodeAttr("b8", Some("generic_decline")),
+            ResponseMessageAttr("b8", Some("Your card was declined.")),
+            LastAttemptDateAttr("b8", Some(LocalDate.of(2021, 10, 26))),
+            SubscriptionIdAttr("b8", Some("A-S87234234")),
+            ProductNameAttr("b8", "prod1"),
+            InvoiceCreatedDateAttr("b8", Some(LocalDate.of(2021, 10, 26))),
+            BillToCountryAttr("b8", Some("United Kingdom")),
+            PaymentFailureTypeAttr("b9", Some("Credit Card")),
+            ResponseCodeAttr("b9", Some("generic_decline")),
+            ResponseMessageAttr("b9", Some("Your card was declined.")),
+            LastAttemptDateAttr("b9", Some(LocalDate.of(2021, 10, 26))),
+            SubscriptionIdAttr("b9", Some("A-S87234234")),
+            ProductNameAttr("b9", "prod1"),
+            InvoiceCreatedDateAttr("b9", Some(LocalDate.of(2021, 10, 26))),
+            BillToCountryAttr("b9", Some("United Kingdom"))
+          ),
+          Seq(
+            CustomEvent(
+              external_id = "b1",
+              app_id = "z1",
+              name = "pf_recovery",
+              time = "2021-10-26T00:00:00Z",
+              properties = eventProperties
+            ),
+            CustomEvent(
+              external_id = "b2",
+              app_id = "z1",
+              name = "pf_cancel_voluntary",
+              time = "2021-10-25T10:15:01Z",
+              properties = eventProperties
+            ),
+            CustomEvent(
+              external_id = "b3",
+              app_id = "z1",
+              name = "pf_cancel_auto",
+              time = "2021-10-27T00:00:00Z",
+              properties = eventProperties
+            ),
+            CustomEvent(
+              external_id = "b4",
+              app_id = "z1",
+              name = "pf_recovery",
+              time = "2021-10-26T00:00:00Z",
+              properties = eventProperties
+            ),
+            CustomEvent(
+              external_id = "b5",
+              app_id = "z1",
+              name = "pf_cancel_voluntary",
+              time = "2021-10-25T10:15:01Z",
+              properties = eventProperties
+            ),
+            CustomEvent(
+              external_id = "b6",
+              app_id = "z1",
+              name = "pf_cancel_auto",
+              time = "2021-10-27T00:00:00Z",
+              properties = eventProperties
+            ),
+            CustomEvent(
+              external_id = "b7",
+              app_id = "z1",
+              name = "pf_recovery",
+              time = "2021-10-26T00:00:00Z",
+              properties = eventProperties
+            ),
+            CustomEvent(
+              external_id = "b8",
+              app_id = "z1",
+              name = "pf_cancel_voluntary",
+              time = "2021-10-25T10:15:01Z",
+              properties = eventProperties
+            ),
+            CustomEvent(
+              external_id = "b9",
+              app_id = "z1",
+              name = "pf_cancel_auto",
+              time = "2021-10-27T00:00:00Z",
+              properties = eventProperties
+            )
+          )
         ),
-        events = Seq(
-          CustomEvent(
-            external_id = "b1",
-            app_id = "z1",
-            name = "pf_recovery",
-            time = "2021-10-26T00:00:00Z",
-            properties = eventProperties
+        BrazeTrackRequest(
+          Seq(
+            PaymentFailureTypeAttr("b10", Some("Credit Card")),
+            ResponseCodeAttr("b10", Some("generic_decline")),
+            ResponseMessageAttr("b10", Some("Your card was declined.")),
+            LastAttemptDateAttr("b10", Some(LocalDate.of(2021, 10, 26))),
+            SubscriptionIdAttr("b10", Some("A-S87234234")),
+            ProductNameAttr("b10", "prod1"),
+            InvoiceCreatedDateAttr("b10", Some(LocalDate.of(2021, 10, 26))),
+            BillToCountryAttr("b10", Some("United Kingdom")),
+            PaymentFailureTypeAttr("b11", Some("Credit Card")),
+            ResponseCodeAttr("b11", Some("generic_decline")),
+            ResponseMessageAttr("b11", Some("Your card was declined.")),
+            LastAttemptDateAttr("b11", Some(LocalDate.of(2021, 10, 26))),
+            SubscriptionIdAttr("b11", Some("A-S87234234")),
+            ProductNameAttr("b11", "prod1"),
+            InvoiceCreatedDateAttr("b11", Some(LocalDate.of(2021, 10, 26))),
+            BillToCountryAttr("b11", Some("United Kingdom")),
+            PaymentFailureTypeAttr("b12", Some("Credit Card")),
+            ResponseCodeAttr("b12", Some("generic_decline")),
+            ResponseMessageAttr("b12", Some("Your card was declined.")),
+            LastAttemptDateAttr("b12", Some(LocalDate.of(2021, 10, 26))),
+            SubscriptionIdAttr("b12", Some("A-S87234234")),
+            ProductNameAttr("b12", "prod1"),
+            InvoiceCreatedDateAttr("b12", Some(LocalDate.of(2021, 10, 26))),
+            BillToCountryAttr("b12", Some("United Kingdom"))
           ),
-          CustomEvent(
-            external_id = "b2",
-            app_id = "z1",
-            name = "pf_cancel_voluntary",
-            time = "2021-10-25T10:15:01Z",
-            properties = eventProperties
-          ),
-          CustomEvent(
-            external_id = "b3",
-            app_id = "z1",
-            name = "pf_cancel_auto",
-            time = "2021-10-27T00:00:00Z",
-            properties = eventProperties
+          Seq(
+            CustomEvent(
+              external_id = "b10",
+              app_id = "z1",
+              name = "pf_recovery",
+              time = "2021-10-26T00:00:00Z",
+              properties = eventProperties
+            ),
+            CustomEvent(
+              external_id = "b11",
+              app_id = "z1",
+              name = "pf_cancel_voluntary",
+              time = "2021-10-25T10:15:01Z",
+              properties = eventProperties
+            ),
+            CustomEvent(
+              external_id = "b12",
+              app_id = "z1",
+              name = "pf_cancel_auto",
+              time = "2021-10-27T00:00:00Z",
+              properties = eventProperties
+            )
           )
         )
       )


### PR DESCRIPTION
The Braze endpoint we use to send custom events and attributes (https://www.braze.com/docs/api/endpoints/user_data/post_user_track/#rate-limit) has a limit of 75 events and 75 attributes per API call. The events are being controlled via the salesforce query here: https://github.com/guardian/payment-failure-comms/blob/4cc472452a1b025b113c0adeefb5e1ca039bd7f6/src/main/scala/payment_failure_comms/SalesforceConnector.scala#L91

 The code has been adjusted to allow for 9 events/records sent in each API call. Each event has 8 attributes and will therefore not surpass the limit. 

 A unit test has been added to ensure requests get split up properly. I've tested processing 10 records locally to ensure that 9 events with 72 attributes get sent in a first request, followed by another request with the last event.