### PR TITLE
Speed up backlog clearance, run lambda every minute

### DIFF
--- a/cfn.yaml
+++ b/cfn.yaml
@@ -20,7 +20,7 @@ Conditions:
 Mappings:
   StageMap:
     PROD:
-      Schedule: 'rate(20 minutes)'
+      Schedule: 'rate(1 minute)'
       SalesforceStage: PROD
       SalesforceUserName: pfCommsAPIUser
       SalesforceAppName: PfComms


### PR DESCRIPTION
Kelvin attempted to process all records which did not get through to Braze between 22/03/2022 and 01/04/2022. This attempt to clear the backlog did not process the records correctly and they did not reach Braze. The issue was due to `PF_Comms_Number_of_Attempts__c` field reaching the maximum of 5 and therefore these records were not being retrieved when running the lambda.

 To fix this, this field was updated to 4 on 3905 records so they can now be processed by the lamba. Around 1000 of these records have already been recovered or cancelled, meaning the lambda should process approximately 3000 records from this backlog.