### PR TITLE
Put lambda back to normal schedule

### DIFF
--- a/cfn.yaml
+++ b/cfn.yaml
@@ -20,7 +20,7 @@ Conditions:
 Mappings:
   StageMap:
     PROD:
-      Schedule: 'rate(1 minute)'
+      Schedule: 'rate(20 minutes)'
       SalesforceStage: PROD
       SalesforceUserName: pfCommsAPIUser
       SalesforceAppName: PfComms


### PR DESCRIPTION
The lambda has finished processing the 3000 records from the backlog so we're putting the lambda back to it's usual schedule.