### PR TITLE
Consider periods with no limit-reached data as OK

### DIFF
--- a/cfn.yaml
+++ b/cfn.yaml
@@ -174,4 +174,4 @@ Resources:
       Statistic: Sum
       Period: 60
       EvaluationPeriods: 1
-      TreatMissingData: ignore
+      TreatMissingData: notBreaching


### PR DESCRIPTION
The limit-reached alarm is based on a metric and once it has been triggered there's no means to move it back to OK.
We could explicitly move it back to OK when the metric falls to 0 but the effect would be the same as treating missing data as OK, which this PR does.

See https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/AlarmThatSendsEmail.html#alarms-and-missing-data

(The work to find out why the alarm triggered and why it doesn't appear to have triggered before is ongoing.)
