### PR TITLE
Retain logs for 90 days

### DIFF
--- a/cfn.yaml
+++ b/cfn.yaml
@@ -53,7 +53,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${AppName}-${Stage}
-      RetentionInDays: 14
+      RetentionInDays: 90
 
   PaymentFailureCommsLambda:
     Type: AWS::Serverless::Function


### PR DESCRIPTION
As the payment failure period is 29 days it's useful to have records from further back than that.
This makes it easier to troubleshoot problems.
The storage of logs is cheap and there is no particularly sensitive data in the log.
