### PR TITLE
Set asynchronous invocation retries to zero

### DIFF
--- a/cfn.yaml
+++ b/cfn.yaml
@@ -129,6 +129,8 @@ Resources:
             - Effect: Allow
               Action: cloudwatch:PutMetricData
               Resource: "*"
+      EventInvokeConfig:
+        MaximumRetryAttempts: 0
 
   FailureAlarm:
     Type: AWS::CloudWatch::Alarm


### PR DESCRIPTION
## What does this change?
This lambda is not intended to retry, but we've found that it is retrying due to the default EventInvokeConfig (asynchronous invocation) retry value of 2. This adds the explicit EventInvokeConfig to the cfn file with a retry limit of 0.