### PR TITLE
require 5 failures in a row to cause an alarm

### DIFF
--- a/cfn.yaml
+++ b/cfn.yaml
@@ -143,16 +143,25 @@ Resources:
         For resolution steps, see https://github.com/guardian/payment-failure-comms/blob/main/README.md#alarms.
       AlarmActions:
         - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:retention-dev
-      MetricName: Errors
-      Namespace: AWS/Lambda
-      Dimensions:
-        - Name: FunctionName
-          Value: !Ref PaymentFailureCommsLambda
+      Metrics:
+        - Id: errors
+          Expression: "FILL(m1,0)"
+          Label: ErrorsCount
+        - Id: m1
+          ReturnData: false
+          MetricStat:
+            Metric:
+              MetricName: Errors
+              Namespace: AWS/Lambda
+              Dimensions:
+                - Name: FunctionName
+                  Value: !Ref PaymentFailureCommsLambda
+            Stat: Sum
+            Period: 60
+            Unit: Count
       ComparisonOperator: GreaterThanOrEqualToThreshold
       Threshold: 5
-      Statistic: Sum
-      Period: 5400
-      EvaluationPeriods: 1
+      EvaluationPeriods: 90
       TreatMissingData: ignore
 
   FailureLimitReachedAlarm:

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -149,7 +149,7 @@ Resources:
         - Name: FunctionName
           Value: !Ref PaymentFailureCommsLambda
       ComparisonOperator: GreaterThanOrEqualToThreshold
-      Threshold: 4
+      Threshold: 5
       Statistic: Sum
       Period: 5400
       EvaluationPeriods: 1

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -160,8 +160,9 @@ Resources:
             Period: 60
             Unit: Count
       ComparisonOperator: GreaterThanOrEqualToThreshold
-      Threshold: 5
+      Threshold: 1
       EvaluationPeriods: 90
+      DatapointsToAlarm: 5
       TreatMissingData: ignore
 
   FailureLimitReachedAlarm:

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -137,9 +137,9 @@ Resources:
     Condition: IsProd
     DependsOn: PaymentFailureCommsLambda
     Properties:
-      AlarmName: "Payment-failure-comms: General failure to send events to Braze"
+      AlarmName: "payment-failure-comms record syncing job is consistently failing to complete"
       AlarmDescription: >
-        IMPACT: If this goes unaddressed, at least one payment-failure event won't be communicated to the customer.
+        IMPACT: Until the job is repaired, new payment-failure events will not be communicated to customers.
         For resolution steps, see https://github.com/guardian/payment-failure-comms/blob/main/README.md#alarms.
       AlarmActions:
         - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:retention-dev
@@ -149,9 +149,9 @@ Resources:
         - Name: FunctionName
           Value: !Ref PaymentFailureCommsLambda
       ComparisonOperator: GreaterThanOrEqualToThreshold
-      Threshold: 3
+      Threshold: 4
       Statistic: Sum
-      Period: 3600
+      Period: 5400
       EvaluationPeriods: 1
       TreatMissingData: ignore
 
@@ -162,7 +162,7 @@ Resources:
     Properties:
       AlarmName: "Action required - payment-failure-comms: failure limit reached for some records"
       AlarmDescription: >
-        IMPACT: If this goes unaddressed, at least one payment-failure event won't be communicated to the customer.
+        IMPACT: At least one payment-failure event will not be communicated to the customer.
         For resolution steps, see https://github.com/guardian/payment-failure-comms/blob/main/README.md#alarms.
       AlarmActions:
         - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:retention-dev


### PR DESCRIPTION
This PR makes it so that 3 failures in a row (every 20 mins) won't sound an alarm - actually it will need 5 failures in a row.

I've also tweaked the alarm names and description to be a bit clearer.