### PR TITLE
move this repo to the right Snyk team

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -11,7 +11,7 @@ jobs:
     uses: guardian/.github/.github/workflows/sbt-node-snyk.yml@main
     with:
       DEBUG: true
-      ORG: the-guardian-cuu
+      ORG: guardian-value
       SKIP_NODE: true
     secrets:
        SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}


### PR DESCRIPTION
previously all reader revenue repos were imported into snyk under the same project, and each subteam looked through them all.

since the new team structure, the responsibliity is clearer per repo
see https://docs.google.com/spreadsheets/d/1hMBm0oIOJMeX93wFifrbW5Oppl2lCIoXN-NvaULrnQw/edit#gid=0

we want each team to have a clearer view of which vulnerabilities they are responsible for in snyk, so there are new snyk projects per team.

This PR updates this repo to appear under the correct project.

Once this is up and running, the old project can be deleted from snyk ui.