### PR TITLE
update to scala 3 (latest)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / scalaVersion := "2.13.18"
+ThisBuild / scalaVersion := "3.7.4"
 
 ThisBuild / scalacOptions ++= Seq(
   "-deprecation",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
 addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.18")
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.1.4")
-addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.3.1")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.6")

--- a/src/main/scala/payment_failure_comms/models/EventTime.scala
+++ b/src/main/scala/payment_failure_comms/models/EventTime.scala
@@ -7,7 +7,7 @@ import java.time.format.DateTimeFormatter.ISO_OFFSET_DATE_TIME
 object EventTime {
 
   def apply(record: PaymentFailureRecord): Either[Failure, String] = {
-    val failOrDate = eitherFailOrDate(record.Id) _
+    val failOrDate = eitherFailOrDate(record.Id)
     record.PF_Comms_Status__c match {
       case "Ready to send entry event"    => failOrDate(record.Initial_Payment_Created_Date__c.map(formatDateTime))
       case "Ready to send recovery event" => failOrDate(record.Recovery_Date__c.map(formatDateTime))

--- a/src/main/scala/payment_failure_comms/models/PaymentFailureRecordUpdate.scala
+++ b/src/main/scala/payment_failure_comms/models/PaymentFailureRecordUpdate.scala
@@ -15,7 +15,7 @@ case class PaymentFailureRecordUpdateRequest(records: Seq[PaymentFailureRecordUp
 
 object PaymentFailureRecordUpdate {
 
-  val eventStageMapping = Map(
+  val eventStageMapping: Map[String, String] = Map(
     "Ready to send entry event" -> "Entry",
     "Ready to send recovery event" -> "Exit",
     "Ready to send voluntary cancel event" -> "Exit",

--- a/src/main/scala/payment_failure_comms/models/brazeTrackEvents.scala
+++ b/src/main/scala/payment_failure_comms/models/brazeTrackEvents.scala
@@ -65,7 +65,7 @@ object BrazeTrackRequest {
       zuoraAppId: String
   ): Either[Failure, Seq[BrazeTrackRequest]] = {
 
-    val processRecordFunc = processRecord(zuoraAppId) _
+    val processRecordFunc = processRecord(zuoraAppId)
 
     def process(
         soFar: Seq[CustomEventWithAttributes],

--- a/src/test/scala/payment_failure_comms/testData/ConnectorTestData.scala
+++ b/src/test/scala/payment_failure_comms/testData/ConnectorTestData.scala
@@ -17,7 +17,7 @@ object ConnectorTestData {
   private def invalidResponseBody = ResponseBody.create(invalidBody, JSON)
 
   case class ResponseModel(field: Int)
-  val validBodyAsClass = ResponseModel(magicNumber)
+  val validBodyAsClass: ResponseModel = ResponseModel(magicNumber)
 
   def successfulResponse: Either[Throwable, Response] = Right(
     new Response.Builder()


### PR DESCRIPTION
while fixing a vulnerability, I noticed this small project is still on scala 2.13.

This PR is the result of using:
`sbt-scala3-migrate` plugin https://docs.scala-lang.org/scala3/guides/migration/tutorial-intro.htm
 and `-rewrite -source:3.7-migration`

and it all seemed fine first time, it made 4 lines of change to the source code.

I also bumped the sbt plugins to latest while I was in.

Tested in CODE
https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252Fpayment-failure-comms-CODE/log-events/2026$252F01$252F12$252F$255B$2524LATEST$255D47acac59c42f43aab15b012f1693105e/2026$252F01$252F12$252F$255B$2524LATEST$255D47acac59c42f43aab15b012f1693105e$3Fstart$3D1768214533482$26refEventId$3D39432501769750851792092035862207811100374796878240612359