### PR TITLE
run it more frequently to catch up backlog

### DIFF
--- a/cfn.yaml
+++ b/cfn.yaml
@@ -20,7 +20,7 @@ Conditions:
 Mappings:
   StageMap:
     PROD:
-      Schedule: 'rate(20 minutes)'
+      Schedule: 'rate(5 minutes)'
       SalesforceStage: PROD
       SalesforceUserName: pfCommsAPIUser
       SalesforceAppName: PfComms


### PR DESCRIPTION
We noticed that payment failure records were not being created in SF for about 2 weeks.  This has now been fixed, but it's meant there's a backlog of about 4k records to write, out of an excpected total of about 500x14=7k

Since this lambda can only process 3600 records a day, the backlog will probably get bigger before it reduces.  Ideally we want to clear it before the next canvas entry tomorrow at 10am, meaning we need to do at least 140 runs before then.

This PR changes it to run every 5 minutes, so it will take about 12 hours to do 140 runs.

The code does one request to idapi per user (braze uuid lookup), and the braze calls batch per 9 users.  None of the systems are likely to be overloaded.

background https://chat.google.com/room/AAAAFNJwTZs/av9B9D9G3c4/6wO6nWxEInU?cls=10