### PR TITLE
Revert "run it more frequently to catch up backlog"

### DIFF
--- a/cfn.yaml
+++ b/cfn.yaml
@@ -20,7 +20,7 @@ Conditions:
 Mappings:
   StageMap:
     PROD:
-      Schedule: 'rate(5 minutes)'
+      Schedule: 'rate(20 minutes)'
       SalesforceStage: PROD
       SalesforceUserName: pfCommsAPIUser
       SalesforceAppName: PfComms


### PR DESCRIPTION
Reverts guardian/payment-failure-comms#293

We no longer need the elevated rate of processing as we've cleared the backlog.