### PR TITLE
add alarms if we don't get enough events coming through

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,7 @@ FROM
 ```
 
 From here, view the record's data in Salesforce to determine the cause of failure. 
+
+For other alarms, e.g. `payment-failure-comms no <something> events recently` follow a similar process, although
+look at whether there are no recent dates e.g. Invoice_Created_Date__c or Recovery_Date__c.  Also check that the
+lambda is actually running.

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -187,3 +187,143 @@ Resources:
       Period: 3600
       EvaluationPeriods: 1
       TreatMissingData: notBreaching
+
+  NoPfEntryAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: IsProd
+    DependsOn: PaymentFailureCommsLambda
+    Properties:
+      AlarmName: "payment-failure-comms no pf_entry events recently"
+      AlarmDescription: >
+        IMPACT: Until the job is repaired, certain payment-failure events will not be communicated to customers.
+        For resolution steps, see https://github.com/guardian/payment-failure-comms/blob/main/README.md#alarms.
+      AlarmActions:
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:alarms-handler-topic-PROD
+      Metrics:
+        - Id: eventCount
+          Expression: "FILL(m1,0)"
+          Label: EventCount
+        - Id: m1
+          ReturnData: false
+          MetricStat:
+            Metric:
+              MetricName: processed-event
+              Namespace: payment-failure-comms
+              Dimensions:
+                - Name: Stage
+                  Value: !Ref Stage
+                - Name: event-name
+                  Value: pf_entry
+            Stat: Sum
+            Period: 60
+            Unit: Count
+      ComparisonOperator: LessThanOrEqualToThreshold
+      Threshold: 100
+      EvaluationPeriods: 1
+      DatapointsToAlarm: 1
+      TreatMissingData: alarm
+
+  NoPfRecoveryAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: IsProd
+    DependsOn: PaymentFailureCommsLambda
+    Properties:
+      AlarmName: "payment-failure-comms no pf_recovery events recently"
+      AlarmDescription: >
+        IMPACT: Until the job is repaired, certain payment-failure events will not be communicated to customers.
+        For resolution steps, see https://github.com/guardian/payment-failure-comms/blob/main/README.md#alarms.
+      AlarmActions:
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:alarms-handler-topic-PROD
+      Metrics:
+        - Id: eventCount
+          Expression: "FILL(m1,0)"
+          Label: EventCount
+        - Id: m1
+          ReturnData: false
+          MetricStat:
+            Metric:
+              MetricName: processed-event
+              Namespace: payment-failure-comms
+              Dimensions:
+                - Name: Stage
+                  Value: !Ref Stage
+                - Name: event-name
+                  Value: pf_recovery
+            Stat: Sum
+            Period: 60
+            Unit: Count
+      ComparisonOperator: LessThanOrEqualToThreshold
+      Threshold: 100
+      EvaluationPeriods: 1
+      DatapointsToAlarm: 1
+      TreatMissingData: alarm
+
+  NoPfCancelVoluntaryAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: IsProd
+    DependsOn: PaymentFailureCommsLambda
+    Properties:
+      AlarmName: "payment-failure-comms no pf_cancel_voluntary events recently"
+      AlarmDescription: >
+        IMPACT: Until the job is repaired, certain payment-failure events will not be communicated to customers.
+        For resolution steps, see https://github.com/guardian/payment-failure-comms/blob/main/README.md#alarms.
+      AlarmActions:
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:alarms-handler-topic-PROD
+      Metrics:
+        - Id: eventCount
+          Expression: "FILL(m1,0)"
+          Label: EventCount
+        - Id: m1
+          ReturnData: false
+          MetricStat:
+            Metric:
+              MetricName: processed-event
+              Namespace: payment-failure-comms
+              Dimensions:
+                - Name: Stage
+                  Value: !Ref Stage
+                - Name: event-name
+                  Value: pf_cancel_voluntary
+            Stat: Sum
+            Period: 60
+            Unit: Count
+      ComparisonOperator: LessThanOrEqualToThreshold
+      Threshold: 100
+      EvaluationPeriods: 1
+      DatapointsToAlarm: 1
+      TreatMissingData: alarm
+
+  NoPfCancelAutoAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: IsProd
+    DependsOn: PaymentFailureCommsLambda
+    Properties:
+      AlarmName: "payment-failure-comms no pf_cancel_auto events recently"
+      AlarmDescription: >
+        IMPACT: Until the job is repaired, certain payment-failure events will not be communicated to customers.
+        For resolution steps, see https://github.com/guardian/payment-failure-comms/blob/main/README.md#alarms.
+      AlarmActions:
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:alarms-handler-topic-PROD
+      Metrics:
+        - Id: eventCount
+          Expression: "FILL(m1,0)"
+          Label: EventCount
+        - Id: m1
+          ReturnData: false
+          MetricStat:
+            Metric:
+              MetricName: processed-event
+              Namespace: payment-failure-comms
+              Dimensions:
+                - Name: Stage
+                  Value: !Ref Stage
+                - Name: event-name
+                  Value: pf_cancel_auto
+            Stat: Sum
+            Period: 60
+            Unit: Count
+      ComparisonOperator: LessThanOrEqualToThreshold
+      Threshold: 100
+      EvaluationPeriods: 1
+      DatapointsToAlarm: 1
+      TreatMissingData: alarm

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -215,7 +215,7 @@ Resources:
                 - Name: event-name
                   Value: pf_entry
             Stat: Sum
-            Period: 60
+            Period: 1800
             Unit: Count
       ComparisonOperator: LessThanOrEqualToThreshold
       Threshold: 100
@@ -250,7 +250,7 @@ Resources:
                 - Name: event-name
                   Value: pf_recovery
             Stat: Sum
-            Period: 60
+            Period: 1800
             Unit: Count
       ComparisonOperator: LessThanOrEqualToThreshold
       Threshold: 100
@@ -285,7 +285,7 @@ Resources:
                 - Name: event-name
                   Value: pf_cancel_voluntary
             Stat: Sum
-            Period: 60
+            Period: 1800
             Unit: Count
       ComparisonOperator: LessThanOrEqualToThreshold
       Threshold: 100
@@ -320,7 +320,7 @@ Resources:
                 - Name: event-name
                   Value: pf_cancel_auto
             Stat: Sum
-            Period: 60
+            Period: 1800
             Unit: Count
       ComparisonOperator: LessThanOrEqualToThreshold
       Threshold: 100

--- a/src/main/scala/payment_failure_comms/Handler.scala
+++ b/src/main/scala/payment_failure_comms/Handler.scala
@@ -14,16 +14,21 @@ object Handler {
 
   def handleRequest(context: Context): Unit = program(context.getLogger)
 
-  def putMetric(stage: String, recordsOn5Failures: Int): Unit = {
+  def putMetric(
+      stage: String,
+      value: Int,
+      metricName: MetricName,
+      extraDimensions: Map[MetricDimensionName, MetricDimensionValue] = Map.empty
+  ): Unit = {
     AwsCloudWatch
       .metricPut(
         MetricRequest(
           MetricNamespace("payment-failure-comms"),
-          MetricName("failure-limit-reached"),
+          metricName,
           Map(
             MetricDimensionName("Stage") -> MetricDimensionValue(stage)
-          ),
-          value = recordsOn5Failures
+          ) ++ extraDimensions,
+          value = value
         )
       ).get
   }
@@ -56,6 +61,19 @@ object Handler {
 
       brazeRequests <- BrazeTrackRequest(augmentedRecords.withBrazeId, config.braze.zuoraAppId)
 
+      eventCounts = (for {
+        brazeTrackRequest <- brazeRequests
+        customEvent <- brazeTrackRequest.events
+      } yield customEvent).groupMapReduce(_.name)(_ => 1)(_ + _)
+      _ = eventCounts.foreach((eventName, count) =>
+        putMetric(
+          config.stage,
+          count,
+          MetricName("processed-event"),
+          Map(MetricDimensionName("event-name") -> MetricDimensionValue(eventName))
+        )
+      )
+
       brazeResult = processBrazeRequests(brazeRequests, config, logger)
 
       updateRecordsRequest = PaymentFailureRecordUpdateRequest(
@@ -64,7 +82,7 @@ object Handler {
         brazeResult
       )
       recordsOn5Failures = updateRecordsRequest.records.count(_.PF_Comms_Number_of_Attempts__c == 5)
-      _ = if (recordsOn5Failures != 0) putMetric(config.stage, recordsOn5Failures)
+      _ = if (recordsOn5Failures != 0) putMetric(config.stage, recordsOn5Failures, MetricName("failure-limit-reached"))
 
       _ <- sfConnector.updateRecords(updateRecordsRequest)
     } yield ()) match {


### PR DESCRIPTION
We had a period with no pf_entry events coming through, due to a sync issue.  We didn't actually get any alarm despite it being broken for nearly 2 weeks.

This PR adds alarms for a minimum number of events.

Threshold to be tuned for each alarm in a few days when it's clear what the numbers are like.

Tested in CODE
https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252Fpayment-failure-comms-CODE/log-events/2026$252F05$252F12$252F$255B$2524LATEST$255D96fcdbc82cc14237a649d5c6485589a1

<img width="345" height="224" alt="image" src="https://github.com/user-attachments/assets/66af4673-ac05-4293-b381-c7c30e1c3c01" />

<img width="324" height="219" alt="image" src="https://github.com/user-attachments/assets/09fb324d-e489-4b9d-869b-55988220c49c" />
