### PR TITLE
fix alarm definition

### DIFF
--- a/cfn.yaml
+++ b/cfn.yaml
@@ -221,7 +221,7 @@ Resources:
       Threshold: 100
       EvaluationPeriods: 1
       DatapointsToAlarm: 1
-      TreatMissingData: alarm
+      TreatMissingData: breaching
 
   NoPfRecoveryAlarm:
     Type: AWS::CloudWatch::Alarm
@@ -256,7 +256,7 @@ Resources:
       Threshold: 100
       EvaluationPeriods: 1
       DatapointsToAlarm: 1
-      TreatMissingData: alarm
+      TreatMissingData: breaching
 
   NoPfCancelVoluntaryAlarm:
     Type: AWS::CloudWatch::Alarm
@@ -291,7 +291,7 @@ Resources:
       Threshold: 100
       EvaluationPeriods: 1
       DatapointsToAlarm: 1
-      TreatMissingData: alarm
+      TreatMissingData: breaching
 
   NoPfCancelAutoAlarm:
     Type: AWS::CloudWatch::Alarm
@@ -326,4 +326,4 @@ Resources:
       Threshold: 100
       EvaluationPeriods: 1
       DatapointsToAlarm: 1
-      TreatMissingData: alarm
+      TreatMissingData: breaching


### PR DESCRIPTION
following on from  https://github.com/guardian/payment-failure-comms/pull/296

I used "alarm" instead of "breaching" for the TreatMissingData property, due to using auto complete incorrectly.

This fixes it.

It didn't show up in CODE because the alarms aren't created at all there.

Tested in PROD https://eu-west-1.console.aws.amazon.com/cloudformation/home?region=eu-west-1#/stacks?filteringStatus=active&filteringText=membership-PROD-payment-failure-comms&viewNested=true