### PR TITLE
better thresholds for low data alarms

### DIFF
--- a/cfn.yaml
+++ b/cfn.yaml
@@ -215,10 +215,10 @@ Resources:
                 - Name: event-name
                   Value: pf_entry
             Stat: Sum
-            Period: 1800
+            Period: 86400
             Unit: Count
       ComparisonOperator: LessThanOrEqualToThreshold
-      Threshold: 100
+      Threshold: 200
       EvaluationPeriods: 1
       DatapointsToAlarm: 1
       TreatMissingData: breaching
@@ -250,10 +250,10 @@ Resources:
                 - Name: event-name
                   Value: pf_recovery
             Stat: Sum
-            Period: 1800
+            Period: 43200
             Unit: Count
       ComparisonOperator: LessThanOrEqualToThreshold
-      Threshold: 100
+      Threshold: 50
       EvaluationPeriods: 1
       DatapointsToAlarm: 1
       TreatMissingData: breaching
@@ -285,10 +285,10 @@ Resources:
                 - Name: event-name
                   Value: pf_cancel_voluntary
             Stat: Sum
-            Period: 1800
+            Period: 86400
             Unit: Count
       ComparisonOperator: LessThanOrEqualToThreshold
-      Threshold: 100
+      Threshold: 10
       EvaluationPeriods: 1
       DatapointsToAlarm: 1
       TreatMissingData: breaching
@@ -320,7 +320,7 @@ Resources:
                 - Name: event-name
                   Value: pf_cancel_auto
             Stat: Sum
-            Period: 1800
+            Period: 86400
             Unit: Count
       ComparisonOperator: LessThanOrEqualToThreshold
       Threshold: 100


### PR DESCRIPTION
following https://github.com/guardian/payment-failure-comms/pull/296

This PR updates the alarm thresholds to realistic values based on data that came through since yesterday:

https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#metricsV2?graph=~(metrics~(~(~'payment-failure-comms~'processed-event~'event-name~'pf_cancel_voluntary~'Stage~'PROD~(id~'m1))~(~'...~'pf_recovery~'.~'.~(id~'m2))~(~'...~'pf_entry~'.~'.~(id~'m3))~(~'...~'pf_cancel_auto~'.~'.~(id~'m4)))~view~'timeSeries~stacked~false~region~'eu-west-1~start~'-PT48H~end~'P0D~stat~'Sum~period~3600~yAxis~(left~(min~0)))&query=~'*7bpayment-failure-comms*2cStage*2cevent-name*7d
<img width="904" height="308" alt="image" src="https://github.com/user-attachments/assets/23333504-ddc5-400c-933e-9864182eb8f6" />



Changeset created in PROD ok (but not applied), see 
https://eu-west-1.console.aws.amazon.com/cloudformation/home?region=eu-west-1#/stacks?filteringText=membership-PROD-payment-failure-comms&filteringStatus=active&viewNested=true