### PR TITLE
better alarm thresholds

### DIFF
--- a/cfn.yaml
+++ b/cfn.yaml
@@ -250,10 +250,10 @@ Resources:
                 - Name: event-name
                   Value: pf_recovery
             Stat: Sum
-            Period: 43200
+            Period: 21600
             Unit: Count
       ComparisonOperator: LessThanOrEqualToThreshold
-      Threshold: 50
+      Threshold: 10
       EvaluationPeriods: 1
       DatapointsToAlarm: 1
       TreatMissingData: breaching


### PR DESCRIPTION
following #298 

This PR tweaks the threshold further, as we only had 45 events in 12 hours but the alarm was on 50.

I've changed to 6 hours (so we can spot breakages the same day) but reduced the threshold to 10, so it could be subtly broken and we would miss it.

The other option is to go for a daily alarm which would include the CPR/payment run and have more predictable numbers.