### PR TITLE
quieter alarm

### DIFF
--- a/cfn.yaml
+++ b/cfn.yaml
@@ -250,10 +250,10 @@ Resources:
                 - Name: event-name
                   Value: pf_recovery
             Stat: Sum
-            Period: 21600
+            Period: 86400
             Unit: Count
       ComparisonOperator: LessThanOrEqualToThreshold
-      Threshold: 10
+      Threshold: 150
       EvaluationPeriods: 1
       DatapointsToAlarm: 1
       TreatMissingData: breaching


### PR DESCRIPTION
Tweaking this recently added alarm as it's a bit noisy - we don't get many overnight as they mostly happen during the payment (CPR) run

before (6 hourly)
<img width="1134" height="459" alt="image" src="https://github.com/user-attachments/assets/bc853608-48ee-4fa4-9f4d-d33dc34f5343" />

suggested (daily)
<img width="1500" height="452" alt="image" src="https://github.com/user-attachments/assets/ce613b4d-8527-4c3f-b53b-b1bec364c96b" />
